### PR TITLE
fix(assessment-cli): suppress false-positive py37 semgrep finding

### DIFF
--- a/assessment-cli/src/rabbit_assessment/sql.py
+++ b/assessment-cli/src/rabbit_assessment/sql.py
@@ -29,8 +29,13 @@ def load_template(name: str) -> str:
     """Return the raw text of a bundled SQL template."""
     if name not in _TEMPLATE_CACHE:
         try:
+            # resources.files() requires Python 3.9+; this package targets
+            # Python >=3.11 (see pyproject.toml), so the 3.7-compat rule is a
+            # false positive here.
             text = (
-                resources.files(_TEMPLATE_PACKAGE).joinpath(name).read_text(encoding="utf-8")
+                resources.files(_TEMPLATE_PACKAGE)  # nosemgrep: python.lang.compatibility.python37.python37-compatibility-importlib2
+                .joinpath(name)
+                .read_text(encoding="utf-8")
             )
         except (FileNotFoundError, ModuleNotFoundError) as exc:
             raise SqlRenderError(f"Unknown SQL template: {name}") from exc


### PR DESCRIPTION
## Problem

The `semgrep/ci` job is [failing on master](https://github.com/followrabbit-ai/awesome-rabbit/actions/runs/27633781078/job/81715431969) with one blocking finding:

```
python.lang.compatibility.python37.python37-compatibility-importlib2
  assessment-cli/src/rabbit_assessment/sql.py:33
```

The rule flags `importlib.resources.files()` as unavailable before Python 3.9. However, `assessment-cli` declares `requires-python = ">=3.11"` in its `pyproject.toml`, so this is a false positive.

## Fix

Add a targeted `# nosemgrep: python.lang.compatibility.python37.python37-compatibility-importlib2` suppression on the `resources.files()` call, with a comment explaining why. Verified locally that the finding is suppressed (0 findings) and the file still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)