### PR TITLE
fix(bq-reverse-proxy): unmark sensitive for_each conditions in env blocks

### DIFF
--- a/bq-reverse-proxy/terraform/main.tf
+++ b/bq-reverse-proxy/terraform/main.tf
@@ -138,7 +138,10 @@ resource "google_cloud_run_v2_service" "proxy" {
       # non-null value. The proxy reads it at startup and uses it as the
       # fallback key for requests that omit `rabbit-api-key`.
       dynamic "env" {
-        for_each = var.default_api_key == null ? [] : [1]
+        # nonsensitive: comparisons against a sensitive var are themselves
+        # sensitive-marked, and dynamic for_each rejects sensitive values.
+        # Only the presence/absence is unmarked here, never the key itself.
+        for_each = nonsensitive(var.default_api_key == null) ? [] : [1]
         content {
           name  = "DEFAULT_API_KEY"
           value = var.default_api_key
@@ -149,7 +152,7 @@ resource "google_cloud_run_v2_service" "proxy" {
       # clients that cannot send the `rabbit-api-key` header. Rendered as
       # "alias1=key1,alias2=key2".
       dynamic "env" {
-        for_each = length(var.api_key_routes) == 0 ? [] : [1]
+        for_each = nonsensitive(length(var.api_key_routes) == 0) ? [] : [1]
         content {
           name  = "API_KEY_ROUTES"
           value = join(",", [for alias, key in var.api_key_routes : "${alias}=${key}"])


### PR DESCRIPTION
## Summary
Terraform plan failed for any caller of the `bq-reverse-proxy` module with:

```
Error: Invalid dynamic for_each value
Cannot use a list of number value in for_each. An iterable collection is required.
```

Root cause: `default_api_key` and `api_key_routes` are declared `sensitive = true`, so the presence checks (`var.default_api_key == null`, `length(var.api_key_routes) == 0`) driving the dynamic `env` blocks were themselves sensitive-marked, and dynamic `for_each` rejects sensitive values (with a misleading error message on some Terraform versions).

Fix: wrap only the boolean presence check in `nonsensitive()`. The API key values themselves remain sensitive.

Verified with `terraform plan` (TF 1.15.6) for all input combinations: key set, routes set, and neither — env vars `DEFAULT_API_KEY` / `API_KEY_ROUTES` render correctly in the JSON plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)