### PR TITLE
fix(bq-reverse-proxy): correct ingress enum to INGRESS_TRAFFIC_INTERNAL_ONLY

### DIFF
--- a/bq-reverse-proxy/README.md
+++ b/bq-reverse-proxy/README.md
@@ -105,7 +105,7 @@ region          = "europe-west3"
 default_api_key = "your-rabbit-api-key"
 
 allow_unauthenticated = true
-ingress               = "INGRESS_TRAFFIC_ALL" # or INGRESS_TRAFFIC_INTERNAL, see below
+ingress               = "INGRESS_TRAFFIC_ALL" # or INGRESS_TRAFFIC_INTERNAL_ONLY, see below
 ```
 
 See [Choosing an Access Model](#choosing-an-access-model) and the [Configuration Reference](#configuration-reference) below.
@@ -142,7 +142,7 @@ Protect the endpoint at the network layer instead:
 
 | Model | Settings | When to use |
 | ----- | -------- | ----------- |
-| **Internal (recommended)** | `allow_unauthenticated = true`, `ingress = "INGRESS_TRAFFIC_INTERNAL"` | All clients run inside your GCP project / VPC / VPC-SC perimeter (Composer, in-VPC Airflow, dbt on GCE). The URL is unreachable from the internet. |
+| **Internal (recommended)** | `allow_unauthenticated = true`, `ingress = "INGRESS_TRAFFIC_INTERNAL_ONLY"` | All clients run inside your GCP project / VPC / VPC-SC perimeter (Composer, in-VPC Airflow, dbt on GCE). The URL is unreachable from the internet. |
 | **Internal + Load Balancer** | `allow_unauthenticated = true`, `ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"` | You want to front the proxy with your own Google Cloud Load Balancer (custom domain, Cloud Armor allowlists). |
 | **Public** | `allow_unauthenticated = true`, `ingress = "INGRESS_TRAFFIC_ALL"` | You use SaaS clients that connect from outside your network (Looker, dbt Cloud). |
 
@@ -614,7 +614,7 @@ If you deployed the previous `bq-proxy` package from this repository:
 | ------------------------------------ | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | Image pull fails on deploy           | Artifact Registry access   | The registry allows all authenticated GCP identities to pull. Make sure the Cloud Run service agent exists (deploy once) and the region prefix in `image_registry` is valid |
 | HTML `401` on every request          | Cloud Run IAM gate         | You set `allow_unauthenticated = false` with SDK clients. Use `allow_unauthenticated = true` + network-level protection (see [Choosing an Access Model](#choosing-an-access-model)) |
-| `404` / connection refused           | Ingress setting            | `INGRESS_TRAFFIC_INTERNAL` blocks traffic from outside your VPC — SaaS clients (Looker, dbt Cloud) need `INGRESS_TRAFFIC_ALL`             |
+| `404` / connection refused           | Ingress setting            | `INGRESS_TRAFFIC_INTERNAL_ONLY` blocks traffic from outside your VPC — SaaS clients (Looker, dbt Cloud) need `INGRESS_TRAFFIC_ALL`             |
 | Health check passes but queries fail | BigQuery API not enabled   | Enable `bigquery.googleapis.com` on your project                                                                                          |
 | Queries succeed but no optimization  | Missing or invalid API key | Verify `default_api_key` is set correctly and `bq_job_optimizer_url` was not overridden. Check logs: `gcloud run services logs read bq-reverse-proxy --region=REGION` |
 | High latency on first request        | Cold start                 | Increase `min_instances` to 1 or higher                                                                                                   |

--- a/bq-reverse-proxy/terraform/terraform.tfvars.example
+++ b/bq-reverse-proxy/terraform/terraform.tfvars.example
@@ -22,7 +22,7 @@ default_api_key = "your-rabbit-api-key"
 # (A) Internal only — clients run inside your VPC / project (recommended
 #     when possible, e.g. Airflow/Composer, in-VPC dbt):
 #       allow_unauthenticated = true
-#       ingress               = "INGRESS_TRAFFIC_INTERNAL"
+#       ingress               = "INGRESS_TRAFFIC_INTERNAL_ONLY"
 #
 # (B) Public endpoint — needed for SaaS clients (Looker, dbt Cloud):
 #       allow_unauthenticated = true

--- a/bq-reverse-proxy/terraform/variables.tf
+++ b/bq-reverse-proxy/terraform/variables.tf
@@ -161,7 +161,7 @@ because they send OAuth2 access tokens scoped to BigQuery, not ID tokens
 audience-bound to the proxy URL. The recommended secure setup is:
 
     allow_unauthenticated = true
-    ingress               = "INGRESS_TRAFFIC_INTERNAL"
+    ingress               = "INGRESS_TRAFFIC_INTERNAL_ONLY"
 
 so the URL is only reachable from the same VPC SC perimeter / Cloud Run
 instances in the same project — no public exposure, no IAM friction.
@@ -176,7 +176,7 @@ variable "ingress" {
   description = <<EOT
 Cloud Run ingress setting. One of:
   - INGRESS_TRAFFIC_ALL                              (default; reachable from public internet)
-  - INGRESS_TRAFFIC_INTERNAL                         (only same-project / VPC SC perimeter / connected Cloud Run)
+  - INGRESS_TRAFFIC_INTERNAL_ONLY                    (only same-project / VPC SC perimeter / connected Cloud Run)
   - INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER           (internal + Google Cloud Load Balancing only)
 
 Pair with allow_unauthenticated=true for the SDK-friendly secure setup.
@@ -186,10 +186,10 @@ EOT
   validation {
     condition = contains([
       "INGRESS_TRAFFIC_ALL",
-      "INGRESS_TRAFFIC_INTERNAL",
+      "INGRESS_TRAFFIC_INTERNAL_ONLY",
       "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER",
     ], var.ingress)
-    error_message = "ingress must be one of INGRESS_TRAFFIC_ALL | INGRESS_TRAFFIC_INTERNAL | INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+    error_message = "ingress must be one of INGRESS_TRAFFIC_ALL | INGRESS_TRAFFIC_INTERNAL_ONLY | INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
   }
 }
 


### PR DESCRIPTION
## Summary
Client feedback flagged the `ingress` variable validation in `bq-reverse-proxy/terraform/variables.tf` (line 189): it listed `INGRESS_TRAFFIC_INTERNAL`, which is not a valid Cloud Run v2 `IngressTraffic` enum value. The correct value is `INGRESS_TRAFFIC_INTERNAL_ONLY` (verified against the [Cloud Run v2 API reference](https://docs.cloud.google.com/run/docs/reference/rest/v2/IngressTraffic)).

With the old validation, `ingress = "INGRESS_TRAFFIC_INTERNAL"` passed `terraform plan` but failed at apply time when the provider rejected the value.

## Changes
- `terraform/variables.tf` — fixed the validation list, error message, and the variable/`allow_unauthenticated` description examples
- `terraform/terraform.tfvars.example` — fixed the recommended internal-only example
- `README.md` — fixed the three doc references

`terraform validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)