### PR TITLE
feat(bq-reverse-proxy): source default API key from Secret Manager

### DIFF
--- a/bq-reverse-proxy/README.md
+++ b/bq-reverse-proxy/README.md
@@ -56,6 +56,8 @@ Before deploying, ensure you have:
     bigquery.googleapis.com \
     --project YOUR_PROJECT
   ```
+
+  If you store the Rabbit API key in Secret Manager (recommended — see [Storing the API Key in Secret Manager](#storing-the-api-key-in-secret-manager)), also enable `secretmanager.googleapis.com`.
 2. **Terraform** >= 1.6 installed locally ([install guide](https://developer.hashicorp.com/terraform/install))
 3. **gcloud CLI** authenticated with a principal that has permissions to create Cloud Run services, service accounts, and IAM bindings. You need **two** logins:
   - `gcloud auth login` — for gcloud CLI commands
@@ -108,7 +110,7 @@ allow_unauthenticated = true
 ingress               = "INGRESS_TRAFFIC_ALL" # or INGRESS_TRAFFIC_INTERNAL_ONLY, see below
 ```
 
-See [Choosing an Access Model](#choosing-an-access-model) and the [Configuration Reference](#configuration-reference) below.
+See [Choosing an Access Model](#choosing-an-access-model) and the [Configuration Reference](#configuration-reference) below. `default_api_key` as a plain variable is the quickest start, but it ends up as a plain-text env var on the service — for production, use the Secret Manager-backed setup instead (see [Storing the API Key in Secret Manager](#storing-the-api-key-in-secret-manager)).
 
 ### Step 2: Initialize and Deploy
 
@@ -132,6 +134,64 @@ curl https://bq-reverse-proxy-xxxxxxxxxx-ey.a.run.app/readyz
 ```
 
 > Use `/readyz` for external health checks. (`/healthz` also exists but is used by Cloud Run's liveness probe and may be intercepted by the platform.) The proxy also exposes Prometheus metrics on `/metrics`.
+
+## Storing the API Key in Secret Manager
+
+Setting `default_api_key` injects the key as a plain-text env var: it is stored in the Cloud Run revision spec and visible in the console to anyone with `run.services.get`. The module supports sourcing `DEFAULT_API_KEY` from Secret Manager instead — Cloud Run then resolves the secret at instance startup, and the console/revision spec only ever show the secret *reference* (e.g. `bq-reverse-proxy-default-api-key:latest`), never the key. Reading the value requires `secretmanager.versions.access` on the secret, which is separately granted and audited.
+
+Prerequisite for both options: `secretmanager.googleapis.com` enabled in the project (see [Prerequisites](#prerequisites)).
+
+### Option A: Module-managed secret
+
+```hcl
+# instead of default_api_key = "..."
+create_default_api_key_secret = true
+```
+
+The module creates a secret named `<service_name>-default-api-key` and grants the proxy's runtime service account `roles/secretmanager.secretAccessor` on it. The secret is created **empty** — the API key itself never passes through Terraform, so it appears in neither the Terraform state nor the revision spec. You add it as a secret version out-of-band, and the Cloud Run rollout only succeeds once a version exists, so deploy in two steps:
+
+```bash
+# 1. Create the secret first (prefix the address with module.<name>. if you
+#    consume this as a module):
+terraform apply -target='google_secret_manager_secret.default_api_key'
+
+# 2. Add the API key as a secret version:
+printf '%s' 'YOUR_RABBIT_API_KEY' | gcloud secrets versions add \
+  bq-reverse-proxy-default-api-key --data-file=- --project YOUR_PROJECT
+
+# 3. Deploy everything else:
+terraform apply
+```
+
+To rotate the key later, add a new version with the same `gcloud secrets versions add` command. With the default `default_api_key_secret_version = "latest"` the new version takes effect on the next revision rollout (any `terraform apply` that touches the service, or `gcloud run services update <service> --region <region>`); running instances keep the value they resolved at startup.
+
+### Option B: Bring your own secret
+
+If the key already lives in a secret you manage elsewhere (possibly in another project):
+
+```hcl
+default_api_key_secret         = "my-rabbit-api-key"                    # short id: secret in project_id
+# default_api_key_secret       = "projects/other-proj/secrets/my-key"   # full name: secret in another project
+default_api_key_secret_version = "latest"                               # or pin a version, e.g. "3"
+```
+
+The module does not manage IAM on secrets it doesn't own — grant the proxy's runtime service account access yourself:
+
+```bash
+gcloud secrets add-iam-policy-binding my-rabbit-api-key \
+  --member "serviceAccount:bq-reverse-proxy-sa@YOUR_PROJECT.iam.gserviceaccount.com" \
+  --role roles/secretmanager.secretAccessor \
+  --project PROJECT_OF_THE_SECRET
+```
+
+(The runtime service account email is available as the `service_account_email` Terraform output.)
+
+### Permissions needed by whoever runs Terraform
+
+- **Option A** additionally requires permission to create secrets and set IAM policy on them — `roles/secretmanager.admin` on the project covers both.
+- **Option B** requires no Secret Manager permission for the Terraform principal at all: the module only writes the secret *reference* into the service config and never reads the secret. Only the runtime service account needs `secretAccessor`, granted by the secret's owner as shown above.
+
+`default_api_key`, `create_default_api_key_secret`, and `default_api_key_secret` are mutually exclusive — Terraform fails the plan if more than one is set.
 
 ## Choosing an Access Model
 
@@ -510,12 +570,15 @@ These tools offer no BigQuery API endpoint override, so they cannot use the prox
 | `project_id` | **Yes** | — | GCP project ID for deployment |
 | `region` | **Yes** | — | GCP region for the Cloud Run service |
 | `bq_job_optimizer_url` | No | `https://api.followrabbit.ai/bq-job-optimizer` | Rabbit BQ Job Optimizer URL. The default is the global public endpoint — right for everyone. `""` = pass-through mode |
-| `default_api_key` | No | `null` | Rabbit API key used for requests without a `rabbit-api-key` header or path alias. In practice: set it (standard BQ tools can't send custom headers) |
+| `default_api_key` | No | `null` | Rabbit API key used for requests without a `rabbit-api-key` header or path alias, as a plain env var. Prefer the Secret Manager variants below (see [Storing the API Key in Secret Manager](#storing-the-api-key-in-secret-manager)) |
+| `create_default_api_key_secret` | No | `false` | Create a Secret Manager secret for the default API key and inject it as a secret-backed env var; you add the key as a secret version out-of-band |
+| `default_api_key_secret` | No | `null` | Existing Secret Manager secret to source the default API key from (short id, or `projects/*/secrets/*` for cross-project) |
+| `default_api_key_secret_version` | No | `latest` | Secret version to pin when using either Secret Manager variant |
 | `api_key_routes` | No | `{}` | Map of URL path alias → Rabbit API key for multi-workload routing (see [Using Multiple API Keys](#using-multiple-api-keys-with-one-deployment)) |
 | `image_registry` | No | `europe-docker.pkg.dev/.../bq-reverse-proxy` | Registry path without tag (see [Container Images](#container-images)) |
 | `image_tag` | No | `latest` | Image version to deploy. Set a release tag (e.g. `v0.1.0`) to pin |
 | `allow_unauthenticated` | No | `false` | Grant `run.invoker` to `allUsers` (see [Choosing an Access Model](#choosing-an-access-model)) |
-| `ingress` | No | `INGRESS_TRAFFIC_ALL` | `..._ALL`, `..._INTERNAL`, or `..._INTERNAL_LOAD_BALANCER` |
+| `ingress` | No | `INGRESS_TRAFFIC_ALL` | `..._ALL`, `..._INTERNAL_ONLY`, or `..._INTERNAL_LOAD_BALANCER` |
 | `invoker_members` | No | `[]` | IAM principals granted `run.invoker` (only when `allow_unauthenticated = false`) |
 | `service_name` | No | `bq-reverse-proxy` | Cloud Run service name |
 | `service_account_email` | No | `null` (created) | Bring your own runtime service account |

--- a/bq-reverse-proxy/README.md
+++ b/bq-reverse-proxy/README.md
@@ -57,7 +57,7 @@ Before deploying, ensure you have:
     --project YOUR_PROJECT
   ```
 
-  If you store the Rabbit API key in Secret Manager (recommended — see [Storing the API Key in Secret Manager](#storing-the-api-key-in-secret-manager)), also enable `secretmanager.googleapis.com`.
+  If you store the Rabbit API key in Secret Manager (recommended — see [Storing the API Keys in Secret Manager](#storing-the-api-keys-in-secret-manager)), also enable `secretmanager.googleapis.com`.
 2. **Terraform** >= 1.6 installed locally ([install guide](https://developer.hashicorp.com/terraform/install))
 3. **gcloud CLI** authenticated with a principal that has permissions to create Cloud Run services, service accounts, and IAM bindings. You need **two** logins:
   - `gcloud auth login` — for gcloud CLI commands
@@ -88,7 +88,7 @@ module "bq_reverse_proxy" {
 
   project_id      = "my-gcp-project"
   region          = "europe-west3"
-  default_api_key = var.rabbit_api_key
+  api_keys = { default = var.rabbit_api_key }
 }
 ```
 
@@ -104,13 +104,13 @@ Edit `terraform.tfvars` with your values:
 ```hcl
 project_id      = "my-gcp-project"
 region          = "europe-west3"
-default_api_key = "your-rabbit-api-key"
+api_keys = { default = "your-rabbit-api-key" }
 
 allow_unauthenticated = true
 ingress               = "INGRESS_TRAFFIC_ALL" # or INGRESS_TRAFFIC_INTERNAL_ONLY, see below
 ```
 
-See [Choosing an Access Model](#choosing-an-access-model) and the [Configuration Reference](#configuration-reference) below. `default_api_key` as a plain variable is the quickest start, but it ends up as a plain-text env var on the service — for production, use the Secret Manager-backed setup instead (see [Storing the API Key in Secret Manager](#storing-the-api-key-in-secret-manager)).
+See [Choosing an Access Model](#choosing-an-access-model) and the [Configuration Reference](#configuration-reference) below. `api_keys` as a plain variable is the quickest start, but it ends up as a plain-text env var on the service — for production, use the Secret Manager-backed setup instead (see [Storing the API Keys in Secret Manager](#storing-the-api-keys-in-secret-manager)).
 
 ### Step 2: Initialize and Deploy
 
@@ -135,62 +135,58 @@ curl https://bq-reverse-proxy-xxxxxxxxxx-ey.a.run.app/readyz
 
 > Use `/readyz` for external health checks. (`/healthz` also exists but is used by Cloud Run's liveness probe and may be intercepted by the platform.) The proxy also exposes Prometheus metrics on `/metrics`.
 
-## Storing the API Key in Secret Manager
+## Storing the API Keys in Secret Manager
 
-Setting `default_api_key` (or `api_key_routes`) injects the key(s) as a plain-text env var: it is stored in the Cloud Run revision spec and visible in the console to anyone with `run.services.get`. The module supports sourcing both `DEFAULT_API_KEY` and `API_KEY_ROUTES` from Secret Manager instead — Cloud Run then resolves the secret at instance startup, and the console/revision spec only ever show the secret *reference* (e.g. `bq-reverse-proxy-default-api-key:latest`), never the key. Reading the value requires `secretmanager.versions.access` on the secret, which is separately granted and audited.
+Setting `api_keys` injects the keys as plain-text env vars: they are stored in the Cloud Run revision spec and visible in the console to anyone with `run.services.get`. The module supports sourcing the whole key map from a **single** Secret Manager secret instead — Cloud Run then resolves it at instance startup, and the console/revision spec only ever show the secret *reference* (e.g. `bq-reverse-proxy-api-keys:latest`), never the keys. Reading the value requires `secretmanager.versions.access` on the secret, which is separately granted and audited.
 
-Everything below is written for the default API key; the multi-key routing variable works identically — same two options, same IAM, same rollout semantics — with this mapping:
+The secret value is the exact string `api_keys` renders to — `alias=key` pairs, comma-separated, with the reserved alias `default` carrying the fallback key:
 
-| | Default key | Path-alias routes |
-|---|---|---|
-| Plain variable | `default_api_key` | `api_key_routes` |
-| Module-managed secret | `create_default_api_key_secret` | `create_api_key_routes_secret` |
-| Existing secret | `default_api_key_secret` (+`_version`) | `api_key_routes_secret` (+`_version`) |
-| Created secret name | `<service_name>-default-api-key` | `<service_name>-api-key-routes` |
-| Secret value | the API key itself | the rendered mapping: `alias1=key1,alias2=key2` |
+```
+default=rabbit-key-root,dbt=rabbit-key-dbt,looker=rabbit-key-looker
+```
 
-For the routes secret, the value is the exact string the plain variable would render to, e.g. `printf '%s' 'dbt=rabbit-key-1,looker=rabbit-key-2' | gcloud secrets versions add bq-reverse-proxy-api-key-routes --data-file=- --project YOUR_PROJECT`. Alias rules (single path segment, no reserved segments — see [Using Multiple API Keys](#using-multiple-api-keys-with-one-deployment)) still apply; with the secret path they are enforced by the proxy at startup rather than by Terraform.
+A single-key deployment's secret is just `default=rabbit-key-root`. Alias rules (single path segment, no reserved segments — see [Using Multiple API Keys](#using-multiple-api-keys-with-one-deployment)) still apply; with the secret path they are enforced by the proxy at startup rather than by Terraform.
 
-Prerequisite for both options: `secretmanager.googleapis.com` enabled in the project (see [Prerequisites](#prerequisites)).
+Prerequisites: `secretmanager.googleapis.com` enabled in the project (see [Prerequisites](#prerequisites)), and proxy image **v0.2.0 or newer** (the first release that understands the `default` alias — older images would treat it as a routable path and start without a fallback key).
 
 ### Option A: Module-managed secret
 
 ```hcl
-# instead of default_api_key = "..."
-create_default_api_key_secret = true
+# instead of api_keys = { ... }
+create_api_keys_secret = true
 ```
 
-The module creates a secret named `<service_name>-default-api-key` and grants the proxy's runtime service account `roles/secretmanager.secretAccessor` on it. The secret is created **empty** — the API key itself never passes through Terraform, so it appears in neither the Terraform state nor the revision spec. You add it as a secret version out-of-band, and the Cloud Run rollout only succeeds once a version exists, so deploy in two steps:
+The module creates a secret named `<service_name>-api-keys` and grants the proxy's runtime service account `roles/secretmanager.secretAccessor` on it. The secret is created **empty** — the keys never pass through Terraform, so they appear in neither the Terraform state nor the revision spec. You add them as a secret version out-of-band, and the Cloud Run rollout only succeeds once a version exists, so deploy in two steps:
 
 ```bash
 # 1. Create the secret first (prefix the address with module.<name>. if you
 #    consume this as a module):
-terraform apply -target='google_secret_manager_secret.default_api_key'
+terraform apply -target='google_secret_manager_secret.api_keys'
 
-# 2. Add the API key as a secret version:
-printf '%s' 'YOUR_RABBIT_API_KEY' | gcloud secrets versions add \
-  bq-reverse-proxy-default-api-key --data-file=- --project YOUR_PROJECT
+# 2. Add the keys as a secret version:
+printf '%s' 'default=YOUR_RABBIT_API_KEY' | gcloud secrets versions add \
+  bq-reverse-proxy-api-keys --data-file=- --project YOUR_PROJECT
 
 # 3. Deploy everything else:
 terraform apply
 ```
 
-To rotate the key later, add a new version with the same `gcloud secrets versions add` command. With the default `default_api_key_secret_version = "latest"` the new version takes effect on the next revision rollout (any `terraform apply` that touches the service, or `gcloud run services update <service> --region <region>`); running instances keep the value they resolved at startup.
+To rotate keys later, add a new version with the same `gcloud secrets versions add` command (the full mapping each time — versions are immutable snapshots). With the default `api_keys_secret_version = "latest"` the new version takes effect on the next revision rollout (any `terraform apply` that touches the service, or `gcloud run services update <service> --region <region>`); running instances keep the value they resolved at startup.
 
 ### Option B: Bring your own secret
 
-If the key already lives in a secret you manage elsewhere (possibly in another project):
+If the keys already live in a secret you manage elsewhere (possibly in another project), in the same `default=key0,alias1=key1` format:
 
 ```hcl
-default_api_key_secret         = "my-rabbit-api-key"                    # short id: secret in project_id
-# default_api_key_secret       = "projects/other-proj/secrets/my-key"   # full name: secret in another project
-default_api_key_secret_version = "latest"                               # or pin a version, e.g. "3"
+api_keys_secret         = "my-rabbit-api-keys"                   # short id: secret in project_id
+# api_keys_secret       = "projects/other-proj/secrets/my-keys"  # full name: secret in another project
+api_keys_secret_version = "latest"                               # or pin a version, e.g. "3"
 ```
 
 The module does not manage IAM on secrets it doesn't own — grant the proxy's runtime service account access yourself:
 
 ```bash
-gcloud secrets add-iam-policy-binding my-rabbit-api-key \
+gcloud secrets add-iam-policy-binding my-rabbit-api-keys \
   --member "serviceAccount:bq-reverse-proxy-sa@YOUR_PROJECT.iam.gserviceaccount.com" \
   --role roles/secretmanager.secretAccessor \
   --project PROJECT_OF_THE_SECRET
@@ -203,7 +199,7 @@ gcloud secrets add-iam-policy-binding my-rabbit-api-key \
 - **Option A** additionally requires permission to create secrets and set IAM policy on them — `roles/secretmanager.admin` on the project covers both.
 - **Option B** requires no Secret Manager permission for the Terraform principal at all: the module only writes the secret *reference* into the service config and never reads the secret. Only the runtime service account needs `secretAccessor`, granted by the secret's owner as shown above.
 
-Within each trio (`default_api_key` / `create_default_api_key_secret` / `default_api_key_secret`, and likewise `api_key_routes` / `create_api_key_routes_secret` / `api_key_routes_secret`) the options are mutually exclusive — Terraform fails the plan if more than one is set. The default key and the routes are independent of each other, and each can use either delivery method.
+`api_keys`, `create_api_keys_secret`, `api_keys_secret`, and the deprecated `default_api_key`/`api_key_routes` pair are mutually exclusive ways to configure the keys — Terraform fails the plan if more than one is set.
 
 ## Choosing an Access Model
 
@@ -222,7 +218,7 @@ For the **public** model, note what exposure actually means: the proxy is statel
 
 ## Using Multiple API Keys with One Deployment
 
-Optimization behavior (pricing mode, reservations, enabled optimizations) is configured on the Rabbit side **per API key**. If all your traffic should use the same settings, one `default_api_key` is all you need — skip this section.
+Optimization behavior (pricing mode, reservations, enabled optimizations) is configured on the Rabbit side **per API key**. If all your traffic should use the same settings, `api_keys = { default = "..." }` is all you need — skip this section.
 
 To give different workloads different settings (e.g. dbt production on a reservation, Looker dashboards on-demand), create one API key per workload in the [Rabbit UI](https://app.followrabbit.ai/api-keys) and route each workload to its key. The proxy resolves the key for each request in this order:
 
@@ -230,13 +226,14 @@ To give different workloads different settings (e.g. dbt production on a reserva
 2. **Path alias** — the mechanism for everything else. Configure aliases in Terraform:
 
    ```hcl
-   api_key_routes = {
-     dbt    = "rabbit-key-for-dbt"
-     looker = "rabbit-key-for-looker"
+   api_keys = {
+     default = "rabbit-key-fallback"
+     dbt     = "rabbit-key-for-dbt"
+     looker  = "rabbit-key-for-looker"
    }
    ```
 
-   This puts the keys in a plain-text env var; to keep them out of the Cloud Run console, source the mapping from Secret Manager instead via `create_api_key_routes_secret` or `api_key_routes_secret` — see [Storing the API Key in Secret Manager](#storing-the-api-key-in-secret-manager).
+   This puts the keys in a plain-text env var; to keep them out of the Cloud Run console, source the mapping from Secret Manager instead via `create_api_keys_secret` or `api_keys_secret` — see [Storing the API Keys in Secret Manager](#storing-the-api-keys-in-secret-manager).
 
    Then point each workload's BigQuery endpoint at `https://<proxy-url>/<alias>`:
 
@@ -246,7 +243,7 @@ To give different workloads different settings (e.g. dbt production on a reserva
    ```
 
    Every client appends the standard `/bigquery/v2/...` path to the endpoint it is given, so requests arrive as `/<alias>/bigquery/v2/...`; the proxy strips the alias, uses that alias's API key, and forwards the canonical path to BigQuery. The API key itself never appears in URLs or request logs — only the alias does.
-3. **`default_api_key`** — fallback for requests that match neither.
+3. **The `default` key** (`api_keys` entry `default`) — fallback for requests that match neither.
 
 Aliases are single path segments of your choosing (they cannot be `bigquery`, `upload`, `batch`, `discovery`, `healthz`, `readyz`, or `metrics`). Adding, removing, or rotating a routed key is a `terraform apply` (in-place revision, no downtime). Requests with an unknown first path segment are forwarded to BigQuery unchanged, which returns a normal 404.
 
@@ -254,7 +251,7 @@ All client integration guides below work identically with an alias URL — where
 
 ### Client Capability Summary
 
-How each supported client points at the proxy, and which options it has for supplying a dedicated API key. Every client can always fall back to `default_api_key` (no key configuration on the client at all). The `rabbit-api-key` header is always optional — where it is supported it is simply an alternative to a path alias.
+How each supported client points at the proxy, and which options it has for supplying a dedicated API key. Every client can always fall back to the `default` key (no key configuration on the client at all). The `rabbit-api-key` header is always optional — where it is supported it is simply an alternative to a path alias.
 
 | Client | Endpoint configuration | `rabbit-api-key` header | Path alias |
 |---|---|---|---|
@@ -273,13 +270,13 @@ How each supported client points at the proxy, and which options it has for supp
 | `bq` CLI | `--api` flag | ❌ | ✅ |
 | JDBC (Simba driver) | connection URL / `rootUrl` property | ❌ | ✅ |
 
-Only custom code using the Java or Go SDK can send the header; every standard tool relies on a path alias for a dedicated key, or on `default_api_key`.
+Only custom code using the Java or Go SDK can send the header; every standard tool relies on a path alias for a dedicated key, or on the `default` key.
 
 ## Connecting Your Clients to the Proxy
 
 Once deployed, configure your BigQuery clients to send requests to the proxy URL instead of the default `bigquery.googleapis.com` endpoint. Below are integration guides for common tools.
 
-> **Multiple workloads?** Each example below uses the bare proxy URL, which resolves to `default_api_key`. To route a client to a specific API key, use `https://<proxy-url>/<alias>` instead — see [Using Multiple API Keys with One Deployment](#using-multiple-api-keys-with-one-deployment).
+> **Multiple workloads?** Each example below uses the bare proxy URL, which resolves to the `default` key. To route a client to a specific API key, use `https://<proxy-url>/<alias>` instead — see [Using Multiple API Keys with One Deployment](#using-multiple-api-keys-with-one-deployment).
 
 ### Python (google-cloud-bigquery)
 
@@ -584,14 +581,12 @@ These tools offer no BigQuery API endpoint override, so they cannot use the prox
 | `project_id` | **Yes** | — | GCP project ID for deployment |
 | `region` | **Yes** | — | GCP region for the Cloud Run service |
 | `bq_job_optimizer_url` | No | `https://api.followrabbit.ai/bq-job-optimizer` | Rabbit BQ Job Optimizer URL. The default is the global public endpoint — right for everyone. `""` = pass-through mode |
-| `default_api_key` | No | `null` | Rabbit API key used for requests without a `rabbit-api-key` header or path alias, as a plain env var. Prefer the Secret Manager variants below (see [Storing the API Key in Secret Manager](#storing-the-api-key-in-secret-manager)) |
-| `create_default_api_key_secret` | No | `false` | Create a Secret Manager secret for the default API key and inject it as a secret-backed env var; you add the key as a secret version out-of-band |
-| `default_api_key_secret` | No | `null` | Existing Secret Manager secret to source the default API key from (short id, or `projects/*/secrets/*` for cross-project) |
-| `default_api_key_secret_version` | No | `latest` | Secret version to pin when using either Secret Manager variant |
-| `api_key_routes` | No | `{}` | Map of URL path alias → Rabbit API key for multi-workload routing, as a plain env var (see [Using Multiple API Keys](#using-multiple-api-keys-with-one-deployment)) |
-| `create_api_key_routes_secret` | No | `false` | Create a Secret Manager secret for the alias → key mapping; you add the mapping (`alias1=key1,alias2=key2`) as a secret version out-of-band |
-| `api_key_routes_secret` | No | `null` | Existing Secret Manager secret holding the alias → key mapping (short id, or `projects/*/secrets/*` for cross-project) |
-| `api_key_routes_secret_version` | No | `latest` | Secret version to pin for the routes secret |
+| `api_keys` | No | `{}` | Alias → Rabbit API key map as a plain env var; the reserved alias `default` is the fallback key (see [Using Multiple API Keys](#using-multiple-api-keys-with-one-deployment)). Prefer the Secret Manager variants below (see [Storing the API Keys in Secret Manager](#storing-the-api-keys-in-secret-manager)) |
+| `create_api_keys_secret` | No | `false` | Create a Secret Manager secret for the whole key map; you add the keys (`default=key0,alias1=key1`) as a secret version out-of-band. Needs image ≥ v0.2.0 |
+| `api_keys_secret` | No | `null` | Existing Secret Manager secret holding the key map (short id, or `projects/*/secrets/*` for cross-project). Needs image ≥ v0.2.0 |
+| `api_keys_secret_version` | No | `latest` | Secret version to pin when the keys come from Secret Manager |
+| `default_api_key` | No | `null` | **Deprecated** — use `api_keys = { default = "..." }`. Still works |
+| `api_key_routes` | No | `{}` | **Deprecated** — use `api_keys` with non-`default` aliases. Still works |
 | `image_registry` | No | `europe-docker.pkg.dev/.../bq-reverse-proxy` | Registry path without tag (see [Container Images](#container-images)) |
 | `image_tag` | No | `latest` | Image version to deploy. Set a release tag (e.g. `v0.1.0`) to pin |
 | `allow_unauthenticated` | No | `false` | Grant `run.invoker` to `allUsers` (see [Choosing an Access Model](#choosing-an-access-model)) |
@@ -625,8 +620,8 @@ These are the environment variables the proxy container reads. The Terraform con
 | `BQ_API_TARGET_URL` | `https://bigquery.googleapis.com` | `bq_api_target_url` | Upstream BigQuery API URL |
 | `BQ_JOB_OPTIMIZER_URL` | _(empty = pass-through)_ | `bq_job_optimizer_url` | Rabbit optimizer base URL. The Terraform default is `https://api.followrabbit.ai/bq-job-optimizer` |
 | `BQ_JOB_OPTIMIZER_TIMEOUT` | `2s` | `bq_job_optimizer_timeout` | Optimizer call timeout |
-| `DEFAULT_API_KEY` | _(unset)_ | `default_api_key` | Fallback Rabbit API key |
-| `API_KEY_ROUTES` | _(unset)_ | `api_key_routes` | Path alias → key map, `alias1=key1,alias2=key2` |
+| `DEFAULT_API_KEY` | _(unset)_ | `api_keys` entry `default` | Fallback Rabbit API key |
+| `API_KEY_ROUTES` | _(unset)_ | `api_keys` (non-`default` aliases) | Path alias → key map, `alias1=key1,alias2=key2` |
 | `REQUEST_TIMEOUT` | `10m` | `request_timeout` | Upstream request timeout |
 | `MAX_BODY_BYTES` | `1048576` | `max_body_bytes` | Max buffered body size |
 | `LOG_LEVEL` | `info` | `log_level` | Log verbosity |
@@ -683,7 +678,7 @@ The tool runs four scenario categories — small queries (latency overhead), med
 If you deployed the previous `bq-proxy` package from this repository:
 
 1. Deploy the new proxy alongside the old one (this package uses the service name `bq-reverse-proxy`, so no conflicts).
-2. Note the config changes: `rabbit_api_key` → `default_api_key`, `rabbit_api_base_url` → `bq_job_optimizer_url` (defaults to the global public endpoint — normally nothing to set), and `default_pricing_mode` / `reservation_ids` are gone (managed server-side by Rabbit).
+2. Note the config changes: `rabbit_api_key` → `api_keys` entry `default`, `rabbit_api_base_url` → `bq_job_optimizer_url` (defaults to the global public endpoint — normally nothing to set), and `default_pricing_mode` / `reservation_ids` are gone (managed server-side by Rabbit).
 3. Switch your clients' endpoint to the new proxy URL.
 4. `terraform destroy` the old deployment.
 
@@ -696,7 +691,7 @@ If you deployed the previous `bq-proxy` package from this repository:
 | HTML `401` on every request          | Cloud Run IAM gate         | You set `allow_unauthenticated = false` with SDK clients. Use `allow_unauthenticated = true` + network-level protection (see [Choosing an Access Model](#choosing-an-access-model)) |
 | `404` / connection refused           | Ingress setting            | `INGRESS_TRAFFIC_INTERNAL_ONLY` blocks traffic from outside your VPC — SaaS clients (Looker, dbt Cloud) need `INGRESS_TRAFFIC_ALL`             |
 | Health check passes but queries fail | BigQuery API not enabled   | Enable `bigquery.googleapis.com` on your project                                                                                          |
-| Queries succeed but no optimization  | Missing or invalid API key | Verify `default_api_key` is set correctly and `bq_job_optimizer_url` was not overridden. Check logs: `gcloud run services logs read bq-reverse-proxy --region=REGION` |
+| Queries succeed but no optimization  | Missing or invalid API key | Verify the `default` API key is set correctly and `bq_job_optimizer_url` was not overridden. Check logs: `gcloud run services logs read bq-reverse-proxy --region=REGION` |
 | High latency on first request        | Cold start                 | Increase `min_instances` to 1 or higher                                                                                                   |
 
 

--- a/bq-reverse-proxy/README.md
+++ b/bq-reverse-proxy/README.md
@@ -137,7 +137,19 @@ curl https://bq-reverse-proxy-xxxxxxxxxx-ey.a.run.app/readyz
 
 ## Storing the API Key in Secret Manager
 
-Setting `default_api_key` injects the key as a plain-text env var: it is stored in the Cloud Run revision spec and visible in the console to anyone with `run.services.get`. The module supports sourcing `DEFAULT_API_KEY` from Secret Manager instead — Cloud Run then resolves the secret at instance startup, and the console/revision spec only ever show the secret *reference* (e.g. `bq-reverse-proxy-default-api-key:latest`), never the key. Reading the value requires `secretmanager.versions.access` on the secret, which is separately granted and audited.
+Setting `default_api_key` (or `api_key_routes`) injects the key(s) as a plain-text env var: it is stored in the Cloud Run revision spec and visible in the console to anyone with `run.services.get`. The module supports sourcing both `DEFAULT_API_KEY` and `API_KEY_ROUTES` from Secret Manager instead — Cloud Run then resolves the secret at instance startup, and the console/revision spec only ever show the secret *reference* (e.g. `bq-reverse-proxy-default-api-key:latest`), never the key. Reading the value requires `secretmanager.versions.access` on the secret, which is separately granted and audited.
+
+Everything below is written for the default API key; the multi-key routing variable works identically — same two options, same IAM, same rollout semantics — with this mapping:
+
+| | Default key | Path-alias routes |
+|---|---|---|
+| Plain variable | `default_api_key` | `api_key_routes` |
+| Module-managed secret | `create_default_api_key_secret` | `create_api_key_routes_secret` |
+| Existing secret | `default_api_key_secret` (+`_version`) | `api_key_routes_secret` (+`_version`) |
+| Created secret name | `<service_name>-default-api-key` | `<service_name>-api-key-routes` |
+| Secret value | the API key itself | the rendered mapping: `alias1=key1,alias2=key2` |
+
+For the routes secret, the value is the exact string the plain variable would render to, e.g. `printf '%s' 'dbt=rabbit-key-1,looker=rabbit-key-2' | gcloud secrets versions add bq-reverse-proxy-api-key-routes --data-file=- --project YOUR_PROJECT`. Alias rules (single path segment, no reserved segments — see [Using Multiple API Keys](#using-multiple-api-keys-with-one-deployment)) still apply; with the secret path they are enforced by the proxy at startup rather than by Terraform.
 
 Prerequisite for both options: `secretmanager.googleapis.com` enabled in the project (see [Prerequisites](#prerequisites)).
 
@@ -191,7 +203,7 @@ gcloud secrets add-iam-policy-binding my-rabbit-api-key \
 - **Option A** additionally requires permission to create secrets and set IAM policy on them — `roles/secretmanager.admin` on the project covers both.
 - **Option B** requires no Secret Manager permission for the Terraform principal at all: the module only writes the secret *reference* into the service config and never reads the secret. Only the runtime service account needs `secretAccessor`, granted by the secret's owner as shown above.
 
-`default_api_key`, `create_default_api_key_secret`, and `default_api_key_secret` are mutually exclusive — Terraform fails the plan if more than one is set.
+Within each trio (`default_api_key` / `create_default_api_key_secret` / `default_api_key_secret`, and likewise `api_key_routes` / `create_api_key_routes_secret` / `api_key_routes_secret`) the options are mutually exclusive — Terraform fails the plan if more than one is set. The default key and the routes are independent of each other, and each can use either delivery method.
 
 ## Choosing an Access Model
 
@@ -223,6 +235,8 @@ To give different workloads different settings (e.g. dbt production on a reserva
      looker = "rabbit-key-for-looker"
    }
    ```
+
+   This puts the keys in a plain-text env var; to keep them out of the Cloud Run console, source the mapping from Secret Manager instead via `create_api_key_routes_secret` or `api_key_routes_secret` — see [Storing the API Key in Secret Manager](#storing-the-api-key-in-secret-manager).
 
    Then point each workload's BigQuery endpoint at `https://<proxy-url>/<alias>`:
 
@@ -574,7 +588,10 @@ These tools offer no BigQuery API endpoint override, so they cannot use the prox
 | `create_default_api_key_secret` | No | `false` | Create a Secret Manager secret for the default API key and inject it as a secret-backed env var; you add the key as a secret version out-of-band |
 | `default_api_key_secret` | No | `null` | Existing Secret Manager secret to source the default API key from (short id, or `projects/*/secrets/*` for cross-project) |
 | `default_api_key_secret_version` | No | `latest` | Secret version to pin when using either Secret Manager variant |
-| `api_key_routes` | No | `{}` | Map of URL path alias → Rabbit API key for multi-workload routing (see [Using Multiple API Keys](#using-multiple-api-keys-with-one-deployment)) |
+| `api_key_routes` | No | `{}` | Map of URL path alias → Rabbit API key for multi-workload routing, as a plain env var (see [Using Multiple API Keys](#using-multiple-api-keys-with-one-deployment)) |
+| `create_api_key_routes_secret` | No | `false` | Create a Secret Manager secret for the alias → key mapping; you add the mapping (`alias1=key1,alias2=key2`) as a secret version out-of-band |
+| `api_key_routes_secret` | No | `null` | Existing Secret Manager secret holding the alias → key mapping (short id, or `projects/*/secrets/*` for cross-project) |
+| `api_key_routes_secret_version` | No | `latest` | Secret version to pin for the routes secret |
 | `image_registry` | No | `europe-docker.pkg.dev/.../bq-reverse-proxy` | Registry path without tag (see [Container Images](#container-images)) |
 | `image_tag` | No | `latest` | Image version to deploy. Set a release tag (e.g. `v0.1.0`) to pin |
 | `allow_unauthenticated` | No | `false` | Grant `run.invoker` to `allUsers` (see [Choosing an Access Model](#choosing-an-access-model)) |

--- a/bq-reverse-proxy/terraform/main.tf
+++ b/bq-reverse-proxy/terraform/main.tf
@@ -26,6 +26,10 @@ locals {
     "version"    = replace(local.version, ".", "-")
   }, var.labels)
 
+  # Secret Manager source for DEFAULT_API_KEY: the module-created secret's
+  # id, a caller-supplied secret reference, or null (plain env / disabled).
+  api_key_secret = var.create_default_api_key_secret ? google_secret_manager_secret.default_api_key[0].secret_id : var.default_api_key_secret
+
   base_env = {
     # PORT is reserved by Cloud Run v2 — it is automatically set to match
     # the container port and cannot be overridden here.
@@ -48,6 +52,29 @@ resource "google_service_account" "proxy" {
   account_id   = "${var.service_name}-sa"
   display_name = "SA for ${var.service_name} Cloud Run service"
   description  = "Managed by the bq-reverse-proxy Terraform module."
+}
+
+# -----------------------------------------------------------------------
+# Secret Manager secret for the default API key (optional)
+# -----------------------------------------------------------------------
+
+resource "google_secret_manager_secret" "default_api_key" {
+  count     = var.create_default_api_key_secret ? 1 : 0
+  project   = var.project_id
+  secret_id = "${var.service_name}-default-api-key"
+  labels    = local.base_labels
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "default_api_key_accessor" {
+  count     = var.create_default_api_key_secret ? 1 : 0
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.default_api_key[0].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = local.effective_sa_member
 }
 
 # -----------------------------------------------------------------------
@@ -148,6 +175,22 @@ resource "google_cloud_run_v2_service" "proxy" {
         }
       }
 
+      # Optional: DEFAULT_API_KEY sourced from Secret Manager instead of a
+      # plain value. Cloud Run resolves the secret at instance startup; the
+      # key never appears in the revision spec.
+      dynamic "env" {
+        for_each = local.api_key_secret == null ? [] : [1]
+        content {
+          name = "DEFAULT_API_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = local.api_key_secret
+              version = var.default_api_key_secret_version
+            }
+          }
+        }
+      }
+
       # Optional: API_KEY_ROUTES maps URL path aliases to API keys for
       # clients that cannot send the `rabbit-api-key` header. Rendered as
       # "alias1=key1,alias2=key2".
@@ -166,6 +209,21 @@ resource "google_cloud_run_v2_service" "proxy" {
   traffic {
     type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
     percent = 100
+  }
+
+  # The revision resolves the secret at startup — make sure the accessor
+  # grant exists before the rollout, not in parallel with it.
+  depends_on = [google_secret_manager_secret_iam_member.default_api_key_accessor]
+
+  lifecycle {
+    precondition {
+      condition = length([for set in [
+        nonsensitive(var.default_api_key != null),
+        var.create_default_api_key_secret,
+        var.default_api_key_secret != null,
+      ] : set if set]) <= 1
+      error_message = "Set at most one of default_api_key, create_default_api_key_secret, and default_api_key_secret — they are mutually exclusive sources for DEFAULT_API_KEY."
+    }
   }
 }
 

--- a/bq-reverse-proxy/terraform/main.tf
+++ b/bq-reverse-proxy/terraform/main.tf
@@ -26,9 +26,11 @@ locals {
     "version"    = replace(local.version, ".", "-")
   }, var.labels)
 
-  # Secret Manager source for DEFAULT_API_KEY: the module-created secret's
-  # id, a caller-supplied secret reference, or null (plain env / disabled).
-  api_key_secret = var.create_default_api_key_secret ? google_secret_manager_secret.default_api_key[0].secret_id : var.default_api_key_secret
+  # Secret Manager sources for DEFAULT_API_KEY / API_KEY_ROUTES: the
+  # module-created secret's id, a caller-supplied secret reference, or
+  # null (plain env / disabled).
+  api_key_secret        = var.create_default_api_key_secret ? google_secret_manager_secret.default_api_key[0].secret_id : var.default_api_key_secret
+  api_key_routes_secret = var.create_api_key_routes_secret ? google_secret_manager_secret.api_key_routes[0].secret_id : var.api_key_routes_secret
 
   base_env = {
     # PORT is reserved by Cloud Run v2 — it is automatically set to match
@@ -55,7 +57,7 @@ resource "google_service_account" "proxy" {
 }
 
 # -----------------------------------------------------------------------
-# Secret Manager secret for the default API key (optional)
+# Secret Manager secrets for the API keys (optional)
 # -----------------------------------------------------------------------
 
 resource "google_secret_manager_secret" "default_api_key" {
@@ -73,6 +75,25 @@ resource "google_secret_manager_secret_iam_member" "default_api_key_accessor" {
   count     = var.create_default_api_key_secret ? 1 : 0
   project   = var.project_id
   secret_id = google_secret_manager_secret.default_api_key[0].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = local.effective_sa_member
+}
+
+resource "google_secret_manager_secret" "api_key_routes" {
+  count     = var.create_api_key_routes_secret ? 1 : 0
+  project   = var.project_id
+  secret_id = "${var.service_name}-api-key-routes"
+  labels    = local.base_labels
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "api_key_routes_accessor" {
+  count     = var.create_api_key_routes_secret ? 1 : 0
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.api_key_routes[0].secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = local.effective_sa_member
 }
@@ -191,6 +212,22 @@ resource "google_cloud_run_v2_service" "proxy" {
         }
       }
 
+      # Optional: API_KEY_ROUTES sourced from Secret Manager. The secret
+      # value uses the same "alias1=key1,alias2=key2" format the plain
+      # variable renders to.
+      dynamic "env" {
+        for_each = local.api_key_routes_secret == null ? [] : [1]
+        content {
+          name = "API_KEY_ROUTES"
+          value_source {
+            secret_key_ref {
+              secret  = local.api_key_routes_secret
+              version = var.api_key_routes_secret_version
+            }
+          }
+        }
+      }
+
       # Optional: API_KEY_ROUTES maps URL path aliases to API keys for
       # clients that cannot send the `rabbit-api-key` header. Rendered as
       # "alias1=key1,alias2=key2".
@@ -211,9 +248,12 @@ resource "google_cloud_run_v2_service" "proxy" {
     percent = 100
   }
 
-  # The revision resolves the secret at startup — make sure the accessor
-  # grant exists before the rollout, not in parallel with it.
-  depends_on = [google_secret_manager_secret_iam_member.default_api_key_accessor]
+  # The revision resolves the secrets at startup — make sure the accessor
+  # grants exist before the rollout, not in parallel with it.
+  depends_on = [
+    google_secret_manager_secret_iam_member.default_api_key_accessor,
+    google_secret_manager_secret_iam_member.api_key_routes_accessor,
+  ]
 
   lifecycle {
     precondition {
@@ -223,6 +263,15 @@ resource "google_cloud_run_v2_service" "proxy" {
         var.default_api_key_secret != null,
       ] : set if set]) <= 1
       error_message = "Set at most one of default_api_key, create_default_api_key_secret, and default_api_key_secret — they are mutually exclusive sources for DEFAULT_API_KEY."
+    }
+
+    precondition {
+      condition = length([for set in [
+        nonsensitive(length(var.api_key_routes) > 0),
+        var.create_api_key_routes_secret,
+        var.api_key_routes_secret != null,
+      ] : set if set]) <= 1
+      error_message = "Set at most one of api_key_routes, create_api_key_routes_secret, and api_key_routes_secret — they are mutually exclusive sources for API_KEY_ROUTES."
     }
   }
 }

--- a/bq-reverse-proxy/terraform/main.tf
+++ b/bq-reverse-proxy/terraform/main.tf
@@ -26,11 +26,15 @@ locals {
     "version"    = replace(local.version, ".", "-")
   }, var.labels)
 
-  # Secret Manager sources for DEFAULT_API_KEY / API_KEY_ROUTES: the
-  # module-created secret's id, a caller-supplied secret reference, or
-  # null (plain env / disabled).
-  api_key_secret        = var.create_default_api_key_secret ? google_secret_manager_secret.default_api_key[0].secret_id : var.default_api_key_secret
-  api_key_routes_secret = var.create_api_key_routes_secret ? google_secret_manager_secret.api_key_routes[0].secret_id : var.api_key_routes_secret
+  # Plain-text key sources: the unified api_keys map ("default" alias =
+  # fallback key) or the deprecated default_api_key / api_key_routes pair.
+  # Split in Terraform so plain mode works with any proxy image version.
+  plain_default_key = var.default_api_key != null ? var.default_api_key : lookup(var.api_keys, "default", null)
+  plain_routes      = length(var.api_key_routes) > 0 ? var.api_key_routes : { for alias, key in var.api_keys : alias => key if alias != "default" }
+
+  # Secret Manager source for the whole key map: the module-created
+  # secret's id, a caller-supplied secret reference, or null (plain env).
+  api_keys_secret = var.create_api_keys_secret ? google_secret_manager_secret.api_keys[0].secret_id : var.api_keys_secret
 
   base_env = {
     # PORT is reserved by Cloud Run v2 — it is automatically set to match
@@ -57,13 +61,13 @@ resource "google_service_account" "proxy" {
 }
 
 # -----------------------------------------------------------------------
-# Secret Manager secrets for the API keys (optional)
+# Secret Manager secret for the API keys (optional)
 # -----------------------------------------------------------------------
 
-resource "google_secret_manager_secret" "default_api_key" {
-  count     = var.create_default_api_key_secret ? 1 : 0
+resource "google_secret_manager_secret" "api_keys" {
+  count     = var.create_api_keys_secret ? 1 : 0
   project   = var.project_id
-  secret_id = "${var.service_name}-default-api-key"
+  secret_id = "${var.service_name}-api-keys"
   labels    = local.base_labels
 
   replication {
@@ -71,29 +75,10 @@ resource "google_secret_manager_secret" "default_api_key" {
   }
 }
 
-resource "google_secret_manager_secret_iam_member" "default_api_key_accessor" {
-  count     = var.create_default_api_key_secret ? 1 : 0
+resource "google_secret_manager_secret_iam_member" "api_keys_accessor" {
+  count     = var.create_api_keys_secret ? 1 : 0
   project   = var.project_id
-  secret_id = google_secret_manager_secret.default_api_key[0].secret_id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = local.effective_sa_member
-}
-
-resource "google_secret_manager_secret" "api_key_routes" {
-  count     = var.create_api_key_routes_secret ? 1 : 0
-  project   = var.project_id
-  secret_id = "${var.service_name}-api-key-routes"
-  labels    = local.base_labels
-
-  replication {
-    auto {}
-  }
-}
-
-resource "google_secret_manager_secret_iam_member" "api_key_routes_accessor" {
-  count     = var.create_api_key_routes_secret ? 1 : 0
-  project   = var.project_id
-  secret_id = google_secret_manager_secret.api_key_routes[0].secret_id
+  secret_id = google_secret_manager_secret.api_keys[0].secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = local.effective_sa_member
 }
@@ -182,60 +167,44 @@ resource "google_cloud_run_v2_service" "proxy" {
         }
       }
 
-      # Optional: DEFAULT_API_KEY is only set when the caller supplies a
-      # non-null value. The proxy reads it at startup and uses it as the
-      # fallback key for requests that omit `rabbit-api-key`.
+      # Optional: fallback API key as a plain env var (from api_keys'
+      # "default" alias or the deprecated default_api_key variable).
       dynamic "env" {
-        # nonsensitive: comparisons against a sensitive var are themselves
+        # nonsensitive: comparisons against a sensitive value are themselves
         # sensitive-marked, and dynamic for_each rejects sensitive values.
         # Only the presence/absence is unmarked here, never the key itself.
-        for_each = nonsensitive(var.default_api_key == null) ? [] : [1]
+        for_each = nonsensitive(local.plain_default_key == null) ? [] : [1]
         content {
           name  = "DEFAULT_API_KEY"
-          value = var.default_api_key
+          value = local.plain_default_key
         }
       }
 
-      # Optional: DEFAULT_API_KEY sourced from Secret Manager instead of a
-      # plain value. Cloud Run resolves the secret at instance startup; the
-      # key never appears in the revision spec.
+      # Optional: path-alias route keys as a plain env var, rendered as
+      # "alias1=key1,alias2=key2".
       dynamic "env" {
-        for_each = local.api_key_secret == null ? [] : [1]
+        for_each = nonsensitive(length(local.plain_routes) == 0) ? [] : [1]
         content {
-          name = "DEFAULT_API_KEY"
-          value_source {
-            secret_key_ref {
-              secret  = local.api_key_secret
-              version = var.default_api_key_secret_version
-            }
-          }
+          name  = "API_KEY_ROUTES"
+          value = join(",", [for alias, key in local.plain_routes : "${alias}=${key}"])
         }
       }
 
-      # Optional: API_KEY_ROUTES sourced from Secret Manager. The secret
-      # value uses the same "alias1=key1,alias2=key2" format the plain
-      # variable renders to.
+      # Optional: the whole key map sourced from Secret Manager. The secret
+      # value uses the same format api_keys renders to, with the "default"
+      # alias carrying the fallback key ("default=key0,dbt=key1" — needs
+      # proxy image >= v0.2.0). Cloud Run resolves the secret at instance
+      # startup; keys never appear in the revision spec.
       dynamic "env" {
-        for_each = local.api_key_routes_secret == null ? [] : [1]
+        for_each = local.api_keys_secret == null ? [] : [1]
         content {
           name = "API_KEY_ROUTES"
           value_source {
             secret_key_ref {
-              secret  = local.api_key_routes_secret
-              version = var.api_key_routes_secret_version
+              secret  = local.api_keys_secret
+              version = var.api_keys_secret_version
             }
           }
-        }
-      }
-
-      # Optional: API_KEY_ROUTES maps URL path aliases to API keys for
-      # clients that cannot send the `rabbit-api-key` header. Rendered as
-      # "alias1=key1,alias2=key2".
-      dynamic "env" {
-        for_each = nonsensitive(length(var.api_key_routes) == 0) ? [] : [1]
-        content {
-          name  = "API_KEY_ROUTES"
-          value = join(",", [for alias, key in var.api_key_routes : "${alias}=${key}"])
         }
       }
     }
@@ -248,30 +217,19 @@ resource "google_cloud_run_v2_service" "proxy" {
     percent = 100
   }
 
-  # The revision resolves the secrets at startup — make sure the accessor
-  # grants exist before the rollout, not in parallel with it.
-  depends_on = [
-    google_secret_manager_secret_iam_member.default_api_key_accessor,
-    google_secret_manager_secret_iam_member.api_key_routes_accessor,
-  ]
+  # The revision resolves the secret at startup — make sure the accessor
+  # grant exists before the rollout, not in parallel with it.
+  depends_on = [google_secret_manager_secret_iam_member.api_keys_accessor]
 
   lifecycle {
     precondition {
       condition = length([for set in [
-        nonsensitive(var.default_api_key != null),
-        var.create_default_api_key_secret,
-        var.default_api_key_secret != null,
+        nonsensitive(length(var.api_keys) > 0),
+        var.create_api_keys_secret,
+        var.api_keys_secret != null,
+        nonsensitive(var.default_api_key != null || length(var.api_key_routes) > 0),
       ] : set if set]) <= 1
-      error_message = "Set at most one of default_api_key, create_default_api_key_secret, and default_api_key_secret — they are mutually exclusive sources for DEFAULT_API_KEY."
-    }
-
-    precondition {
-      condition = length([for set in [
-        nonsensitive(length(var.api_key_routes) > 0),
-        var.create_api_key_routes_secret,
-        var.api_key_routes_secret != null,
-      ] : set if set]) <= 1
-      error_message = "Set at most one of api_key_routes, create_api_key_routes_secret, and api_key_routes_secret — they are mutually exclusive sources for API_KEY_ROUTES."
+      error_message = "Configure the API keys through exactly one mechanism: api_keys, create_api_keys_secret, api_keys_secret, or the deprecated default_api_key/api_key_routes pair."
     }
   }
 }

--- a/bq-reverse-proxy/terraform/outputs.tf
+++ b/bq-reverse-proxy/terraform/outputs.tf
@@ -18,14 +18,9 @@ output "image" {
   value       = local.resolved_image
 }
 
-output "default_api_key_secret_id" {
-  description = "Secret Manager secret id holding the default API key (only when create_default_api_key_secret = true). Add the key with: gcloud secrets versions add <this> --data-file=- --project <project_id>"
-  value       = var.create_default_api_key_secret ? google_secret_manager_secret.default_api_key[0].secret_id : null
-}
-
-output "api_key_routes_secret_id" {
-  description = "Secret Manager secret id holding the API key routes mapping (only when create_api_key_routes_secret = true). Add the mapping with: gcloud secrets versions add <this> --data-file=- --project <project_id>"
-  value       = var.create_api_key_routes_secret ? google_secret_manager_secret.api_key_routes[0].secret_id : null
+output "api_keys_secret_id" {
+  description = "Secret Manager secret id holding the API keys (only when create_api_keys_secret = true). Add the keys with: gcloud secrets versions add <this> --data-file=- --project <project_id>"
+  value       = var.create_api_keys_secret ? google_secret_manager_secret.api_keys[0].secret_id : null
 }
 
 output "version" {

--- a/bq-reverse-proxy/terraform/outputs.tf
+++ b/bq-reverse-proxy/terraform/outputs.tf
@@ -23,6 +23,11 @@ output "default_api_key_secret_id" {
   value       = var.create_default_api_key_secret ? google_secret_manager_secret.default_api_key[0].secret_id : null
 }
 
+output "api_key_routes_secret_id" {
+  description = "Secret Manager secret id holding the API key routes mapping (only when create_api_key_routes_secret = true). Add the mapping with: gcloud secrets versions add <this> --data-file=- --project <project_id>"
+  value       = var.create_api_key_routes_secret ? google_secret_manager_secret.api_key_routes[0].secret_id : null
+}
+
 output "version" {
   description = "Version string baked into this module copy (useful for asserting the right pin was consumed)."
   value       = local.version

--- a/bq-reverse-proxy/terraform/outputs.tf
+++ b/bq-reverse-proxy/terraform/outputs.tf
@@ -18,6 +18,11 @@ output "image" {
   value       = local.resolved_image
 }
 
+output "default_api_key_secret_id" {
+  description = "Secret Manager secret id holding the default API key (only when create_default_api_key_secret = true). Add the key with: gcloud secrets versions add <this> --data-file=- --project <project_id>"
+  value       = var.create_default_api_key_secret ? google_secret_manager_secret.default_api_key[0].secret_id : null
+}
+
 output "version" {
   description = "Version string baked into this module copy (useful for asserting the right pin was consumed)."
   value       = local.version

--- a/bq-reverse-proxy/terraform/terraform.tfvars.example
+++ b/bq-reverse-proxy/terraform/terraform.tfvars.example
@@ -5,29 +5,35 @@
 project_id = "my-gcp-project"
 region     = "europe-west3" # co-locate with your BigQuery datasets
 
-# Rabbit API key — create one yourself in the Rabbit UI at
+# Rabbit API keys — create them yourself in the Rabbit UI at
 # https://app.followrabbit.ai/api-keys (no need to contact Rabbit support).
-# Used for all requests that don't carry their own `rabbit-api-key` header
-# (i.e. all standard BigQuery tools). Without it the proxy runs in
-# pass-through mode.
+# One alias => key map; the reserved alias "default" is the fallback key for
+# requests without a `rabbit-api-key` header or path alias (i.e. all standard
+# BigQuery tools). Extra aliases route workloads via
+# https://<proxy-url>/<alias> — see "Using Multiple API Keys" in the README.
+# Without any key the proxy runs in pass-through mode.
 #
 # Pick ONE of the three delivery options below (they are mutually exclusive).
 # The Secret Manager options need secretmanager.googleapis.com enabled and
-# keep the key out of the Cloud Run revision spec / console — see
-# "Storing the API Key in Secret Manager" in the README.
+# proxy image >= v0.2.0, and keep the keys out of the Cloud Run revision
+# spec / console — see "Storing the API Keys in Secret Manager" in the README.
 
-# (1) Quick start: plain env var (key visible in the Cloud Run console).
-default_api_key = "your-rabbit-api-key"
+# (1) Quick start: plain env vars (keys visible in the Cloud Run console).
+api_keys = {
+  default = "your-rabbit-api-key"
+  # dbt    = "your-rabbit-api-key-for-dbt"
+}
 
-# (2) Recommended: module-created Secret Manager secret. Add the key as a
+# (2) Recommended: module-created Secret Manager secret. Add the keys as a
 #     secret version out-of-band after the secret exists:
-#       printf '%s' 'KEY' | gcloud secrets versions add \
-#         bq-reverse-proxy-default-api-key --data-file=- --project my-gcp-project
-# create_default_api_key_secret = true
+#       printf '%s' 'default=KEY0,dbt=KEY1' | gcloud secrets versions add \
+#         bq-reverse-proxy-api-keys --data-file=- --project my-gcp-project
+# create_api_keys_secret = true
 
-# (3) Bring your own secret (grant the runtime SA secretAccessor yourself).
-# default_api_key_secret         = "projects/other-proj/secrets/my-rabbit-key"
-# default_api_key_secret_version = "latest"
+# (3) Bring your own secret in the same "default=key0,alias1=key1" format
+#     (grant the runtime SA secretAccessor yourself).
+# api_keys_secret         = "projects/other-proj/secrets/my-rabbit-keys"
+# api_keys_secret_version = "latest"
 
 # -----------------------------------------------------------------------
 # Access model — pick one

--- a/bq-reverse-proxy/terraform/terraform.tfvars.example
+++ b/bq-reverse-proxy/terraform/terraform.tfvars.example
@@ -10,7 +10,24 @@ region     = "europe-west3" # co-locate with your BigQuery datasets
 # Used for all requests that don't carry their own `rabbit-api-key` header
 # (i.e. all standard BigQuery tools). Without it the proxy runs in
 # pass-through mode.
+#
+# Pick ONE of the three delivery options below (they are mutually exclusive).
+# The Secret Manager options need secretmanager.googleapis.com enabled and
+# keep the key out of the Cloud Run revision spec / console — see
+# "Storing the API Key in Secret Manager" in the README.
+
+# (1) Quick start: plain env var (key visible in the Cloud Run console).
 default_api_key = "your-rabbit-api-key"
+
+# (2) Recommended: module-created Secret Manager secret. Add the key as a
+#     secret version out-of-band after the secret exists:
+#       printf '%s' 'KEY' | gcloud secrets versions add \
+#         bq-reverse-proxy-default-api-key --data-file=- --project my-gcp-project
+# create_default_api_key_secret = true
+
+# (3) Bring your own secret (grant the runtime SA secretAccessor yourself).
+# default_api_key_secret         = "projects/other-proj/secrets/my-rabbit-key"
+# default_api_key_secret_version = "latest"
 
 # -----------------------------------------------------------------------
 # Access model — pick one

--- a/bq-reverse-proxy/terraform/variables.tf
+++ b/bq-reverse-proxy/terraform/variables.tf
@@ -70,11 +70,49 @@ Default Rabbit API key used when a client request does not carry the
 `rabbit-api-key` header. Leave null to disable — unauthenticated clients
 will then bypass the optimizer entirely.
 
-The caller is responsible for sourcing the secret (e.g. via a
-google_secret_manager_secret_version data source in the root module) and
-passing the plain string here. This module does not manage Secret Manager.
+The key is injected as a plain-text env var, visible in the Cloud Run
+revision spec to anyone with run.services.get. Prefer the Secret Manager
+path instead: set `create_default_api_key_secret = true` (module-managed
+secret) or `default_api_key_secret` (bring your own). Mutually exclusive
+with both.
 EOT
   default     = null
+}
+
+variable "create_default_api_key_secret" {
+  type        = bool
+  description = <<EOT
+Create a Secret Manager secret named "<service_name>-default-api-key" and
+inject DEFAULT_API_KEY from it (env-var-from-secret — the key never appears
+in the revision spec or console). The module grants the runtime service
+account roles/secretmanager.secretAccessor on it. The secret is created
+EMPTY: add the API key as a secret version out-of-band (see the README for
+the gcloud command) — the first Cloud Run rollout only succeeds once a
+version exists. Mutually exclusive with `default_api_key` and
+`default_api_key_secret`.
+EOT
+  default     = false
+}
+
+variable "default_api_key_secret" {
+  type        = string
+  description = <<EOT
+Existing Secret Manager secret holding the default Rabbit API key, injected
+as DEFAULT_API_KEY via env-var-from-secret. Use the short secret id for a
+secret in `project_id`, or the full "projects/<p>/secrets/<name>" resource
+name for a secret in another project. The module does NOT manage IAM on
+secrets it doesn't own — grant the runtime service account
+roles/secretmanager.secretAccessor on the secret yourself (see README).
+Mutually exclusive with `default_api_key` and
+`create_default_api_key_secret`.
+EOT
+  default     = null
+}
+
+variable "default_api_key_secret_version" {
+  type        = string
+  description = "Secret version to pin DEFAULT_API_KEY to when using a Secret Manager secret. Note: with \"latest\", new versions only take effect on the next revision rollout, not on running instances."
+  default     = "latest"
 }
 
 variable "api_key_routes" {

--- a/bq-reverse-proxy/terraform/variables.tf
+++ b/bq-reverse-proxy/terraform/variables.tf
@@ -59,127 +59,117 @@ EOT
 }
 
 # -----------------------------------------------------------------------
-# API key — fallback only
+# API keys
 # -----------------------------------------------------------------------
+
+variable "api_keys" {
+  type        = map(string)
+  sensitive   = true
+  description = <<EOT
+Rabbit API keys as one alias => key map. The reserved alias "default" is
+the fallback key used when a request carries no `rabbit-api-key` header
+and matches no path alias — for a single-key deployment that's the only
+entry you need:
+
+  api_keys = { default = var.rabbit_api_key }
+
+Every other alias routes a workload: clients point their BigQuery endpoint
+at `https://<proxy-url>/<alias>` and the proxy resolves that alias's key.
+
+  api_keys = {
+    default = var.rabbit_api_key
+    dbt     = var.rabbit_api_key_dbt
+    looker  = var.rabbit_api_key_looker
+  }
+
+Aliases must be single path segments and must not collide with reserved
+segments (bigquery, upload, batch, discovery, healthz, readyz, metrics).
+Key resolution order in the proxy: `rabbit-api-key` header, then path
+alias, then the "default" key.
+
+The keys are injected as plain-text env vars, visible in the Cloud Run
+revision spec to anyone with run.services.get. Prefer the Secret Manager
+path instead: `create_api_keys_secret = true` (module-managed secret) or
+`api_keys_secret` (bring your own). Mutually exclusive with both.
+EOT
+  default     = {}
+
+  validation {
+    condition = alltrue([
+      for alias, _ in var.api_keys :
+      can(regex("^[^/]+$", alias)) && !contains(["bigquery", "upload", "batch", "discovery", "healthz", "readyz", "metrics"], alias)
+    ])
+    error_message = "Aliases must be single path segments and must not be a reserved segment (bigquery, upload, batch, discovery, healthz, readyz, metrics)."
+  }
+}
+
+variable "create_api_keys_secret" {
+  type        = bool
+  description = <<EOT
+Create a Secret Manager secret named "<service_name>-api-keys" and inject
+the keys from it (env-var-from-secret — keys never appear in the revision
+spec or console). The module grants the runtime service account
+roles/secretmanager.secretAccessor on it. The secret is created EMPTY: add
+the keys as a secret version out-of-band (see the README for the gcloud
+command) in the same alias=key format `api_keys` renders to, e.g.
+"default=key0,dbt=key1" — the first Cloud Run rollout only succeeds once a
+version exists. Requires proxy image >= v0.2.0 (support for the "default"
+alias). Mutually exclusive with `api_keys` and `api_keys_secret`.
+EOT
+  default     = false
+}
+
+variable "api_keys_secret" {
+  type        = string
+  description = <<EOT
+Existing Secret Manager secret holding the alias => key mapping in
+"default=key0,alias1=key1" format (see `api_keys` for alias semantics),
+injected via env-var-from-secret. Use the short secret id for a secret in
+`project_id`, or the full "projects/<p>/secrets/<name>" resource name for
+a secret in another project. The module does NOT manage IAM on secrets it
+doesn't own — grant the runtime service account
+roles/secretmanager.secretAccessor on the secret yourself (see README).
+Requires proxy image >= v0.2.0. Mutually exclusive with `api_keys` and
+`create_api_keys_secret`.
+EOT
+  default     = null
+}
+
+variable "api_keys_secret_version" {
+  type        = string
+  description = "Secret version to pin when the keys come from Secret Manager. Note: with \"latest\", new versions only take effect on the next revision rollout, not on running instances."
+  default     = "latest"
+}
 
 variable "default_api_key" {
   type        = string
   sensitive   = true
   description = <<EOT
-Default Rabbit API key used when a client request does not carry the
-`rabbit-api-key` header. Leave null to disable — unauthenticated clients
-will then bypass the optimizer entirely.
-
-The key is injected as a plain-text env var, visible in the Cloud Run
-revision spec to anyone with run.services.get. Prefer the Secret Manager
-path instead: set `create_default_api_key_secret = true` (module-managed
-secret) or `default_api_key_secret` (bring your own). Mutually exclusive
-with both.
+DEPRECATED: use `api_keys = { default = "..." }` (or its Secret Manager
+variants) instead. Kept for backward compatibility; still works, but new
+configuration options land on `api_keys` only. Mutually exclusive with
+`api_keys` and the secret variants.
 EOT
   default     = null
-}
-
-variable "create_default_api_key_secret" {
-  type        = bool
-  description = <<EOT
-Create a Secret Manager secret named "<service_name>-default-api-key" and
-inject DEFAULT_API_KEY from it (env-var-from-secret — the key never appears
-in the revision spec or console). The module grants the runtime service
-account roles/secretmanager.secretAccessor on it. The secret is created
-EMPTY: add the API key as a secret version out-of-band (see the README for
-the gcloud command) — the first Cloud Run rollout only succeeds once a
-version exists. Mutually exclusive with `default_api_key` and
-`default_api_key_secret`.
-EOT
-  default     = false
-}
-
-variable "default_api_key_secret" {
-  type        = string
-  description = <<EOT
-Existing Secret Manager secret holding the default Rabbit API key, injected
-as DEFAULT_API_KEY via env-var-from-secret. Use the short secret id for a
-secret in `project_id`, or the full "projects/<p>/secrets/<name>" resource
-name for a secret in another project. The module does NOT manage IAM on
-secrets it doesn't own — grant the runtime service account
-roles/secretmanager.secretAccessor on the secret yourself (see README).
-Mutually exclusive with `default_api_key` and
-`create_default_api_key_secret`.
-EOT
-  default     = null
-}
-
-variable "default_api_key_secret_version" {
-  type        = string
-  description = "Secret version to pin DEFAULT_API_KEY to when using a Secret Manager secret. Note: with \"latest\", new versions only take effect on the next revision rollout, not on running instances."
-  default     = "latest"
-}
-
-variable "create_api_key_routes_secret" {
-  type        = bool
-  description = <<EOT
-Create a Secret Manager secret named "<service_name>-api-key-routes" and
-inject API_KEY_ROUTES from it. Works exactly like
-`create_default_api_key_secret`: the secret is created EMPTY and you add
-the mapping as a secret version out-of-band, in the same rendered format
-the plain variable produces: "alias1=key1,alias2=key2" (see README).
-Mutually exclusive with `api_key_routes` and `api_key_routes_secret`.
-EOT
-  default     = false
-}
-
-variable "api_key_routes_secret" {
-  type        = string
-  description = <<EOT
-Existing Secret Manager secret holding the path-alias => API key mapping
-in "alias1=key1,alias2=key2" format, injected as API_KEY_ROUTES. Short
-secret id for a secret in `project_id`, or full "projects/<p>/secrets/<name>"
-for another project. Grant the runtime service account
-roles/secretmanager.secretAccessor on it yourself (see README).
-Mutually exclusive with `api_key_routes` and `create_api_key_routes_secret`.
-EOT
-  default     = null
-}
-
-variable "api_key_routes_secret_version" {
-  type        = string
-  description = "Secret version to pin API_KEY_ROUTES to when using a Secret Manager secret. Same rollout semantics as default_api_key_secret_version."
-  default     = "latest"
 }
 
 variable "api_key_routes" {
   type        = map(string)
   sensitive   = true
   description = <<EOT
-Map of URL path alias => Rabbit API key, for running multiple workloads
-(each with its own API key and optimization settings) through one proxy
-deployment. Clients that cannot send the `rabbit-api-key` header point
-their BigQuery endpoint at `https://<proxy-url>/<alias>` and the proxy
-resolves the key from the alias. Example:
-
-  api_key_routes = {
-    dbt    = var.rabbit_api_key_dbt
-    looker = var.rabbit_api_key_looker
-  }
-
-Aliases must be single path segments and must not collide with reserved
-segments (bigquery, upload, batch, discovery, healthz, readyz, metrics).
-Key resolution order in the proxy: `rabbit-api-key` header, then path
-alias, then `default_api_key`.
-
-The keys are injected as a plain-text env var, visible in the Cloud Run
-revision spec. Prefer the Secret Manager path instead: set
-`create_api_key_routes_secret = true` or `api_key_routes_secret`.
-Mutually exclusive with both.
+DEPRECATED: use `api_keys` (non-"default" aliases) or its Secret Manager
+variants instead. Kept for backward compatibility; still works, but new
+configuration options land on `api_keys` only. Mutually exclusive with
+`api_keys` and the secret variants.
 EOT
   default     = {}
 
   validation {
     condition = alltrue([
       for alias, _ in var.api_key_routes :
-      can(regex("^[^/]+$", alias)) && !contains(["bigquery", "upload", "batch", "discovery", "healthz", "readyz", "metrics"], alias)
+      can(regex("^[^/]+$", alias)) && !contains(["default", "bigquery", "upload", "batch", "discovery", "healthz", "readyz", "metrics"], alias)
     ])
-    error_message = "Aliases must be single path segments and must not be a reserved segment (bigquery, upload, batch, discovery, healthz, readyz, metrics)."
+    error_message = "Aliases must be single path segments and must not be a reserved segment (default, bigquery, upload, batch, discovery, healthz, readyz, metrics)."
   }
 }
 

--- a/bq-reverse-proxy/terraform/variables.tf
+++ b/bq-reverse-proxy/terraform/variables.tf
@@ -115,6 +115,38 @@ variable "default_api_key_secret_version" {
   default     = "latest"
 }
 
+variable "create_api_key_routes_secret" {
+  type        = bool
+  description = <<EOT
+Create a Secret Manager secret named "<service_name>-api-key-routes" and
+inject API_KEY_ROUTES from it. Works exactly like
+`create_default_api_key_secret`: the secret is created EMPTY and you add
+the mapping as a secret version out-of-band, in the same rendered format
+the plain variable produces: "alias1=key1,alias2=key2" (see README).
+Mutually exclusive with `api_key_routes` and `api_key_routes_secret`.
+EOT
+  default     = false
+}
+
+variable "api_key_routes_secret" {
+  type        = string
+  description = <<EOT
+Existing Secret Manager secret holding the path-alias => API key mapping
+in "alias1=key1,alias2=key2" format, injected as API_KEY_ROUTES. Short
+secret id for a secret in `project_id`, or full "projects/<p>/secrets/<name>"
+for another project. Grant the runtime service account
+roles/secretmanager.secretAccessor on it yourself (see README).
+Mutually exclusive with `api_key_routes` and `create_api_key_routes_secret`.
+EOT
+  default     = null
+}
+
+variable "api_key_routes_secret_version" {
+  type        = string
+  description = "Secret version to pin API_KEY_ROUTES to when using a Secret Manager secret. Same rollout semantics as default_api_key_secret_version."
+  default     = "latest"
+}
+
 variable "api_key_routes" {
   type        = map(string)
   sensitive   = true
@@ -134,6 +166,11 @@ Aliases must be single path segments and must not collide with reserved
 segments (bigquery, upload, batch, discovery, healthz, readyz, metrics).
 Key resolution order in the proxy: `rabbit-api-key` header, then path
 alias, then `default_api_key`.
+
+The keys are injected as a plain-text env var, visible in the Cloud Run
+revision spec. Prefer the Secret Manager path instead: set
+`create_api_key_routes_secret = true` or `api_key_routes_secret`.
+Mutually exclusive with both.
 EOT
   default     = {}
 


### PR DESCRIPTION
## Summary
Implements #62 (requested by GFS security) with a **unified key interface**: all Rabbit API keys — the fallback key and the path-alias route keys — are one `api_keys` map, deliverable either as plain env vars or from a **single** Secret Manager secret so the keys never appear in the revision spec, console, or Terraform state.

Depends on followrabbit-ai/bq-reverse-proxy#30 (reserved `default` alias in `API_KEY_ROUTES`) for the secret modes; plain mode works with any image version.

## Interface (one mechanism at a time, enforced by a plan-time precondition)
| Mode | Config |
|---|---|
| Plain env vars | `api_keys = { default = "key0", dbt = "key1" }` — `default` is the fallback key; Terraform splits it into `DEFAULT_API_KEY` + `API_KEY_ROUTES`, so this works with any image version |
| Module-managed secret | `create_api_keys_secret = true` — creates `<service_name>-api-keys` (empty) + `secretAccessor` for the runtime SA; keys added out-of-band as `default=key0,dbt=key1` (image ≥ v0.2.0) |
| Bring your own secret | `api_keys_secret` (+`_version`) — short id or `projects/*/secrets/*` cross-project; IAM stays with the secret owner (image ≥ v0.2.0) |
| Deprecated | `default_api_key` / `api_key_routes` keep working and render bit-identically (no revision churn on upgrade) |

## Details
- Service `depends_on` the accessor grant so the first rollout doesn't race the IAM binding
- New `api_keys_secret_id` output for the `gcloud secrets versions add` step
- README: "Storing the API Keys in Secret Manager" section (single secret, value format, deploy ordering, rotation semantics of `latest`, `secretmanager.googleapis.com` prerequisite, image ≥ v0.2.0 note, Terraform-principal permissions per mode), all examples switched to `api_keys`, config table marks the deprecated variables
- tfvars.example rewritten around the three delivery options
- Drive-by: fixed a leftover abbreviated `..._INTERNAL` → `..._INTERNAL_ONLY` in the config reference table (escaped the regex in #60)

## Testing
`terraform validate` passes; JSON-plan assertions verified: unified plain mode renders `DEFAULT_API_KEY=k0` + `API_KEY_ROUTES=dbt=k1`, legacy variables render identically to master, secret mode plans one secret + IAM member + `secret_key_ref` env, and mixing mechanisms fails the plan.

Closes: #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)