### PR TITLE
feat(bq-reverse-proxy): per-workload optimizer_configs variable (re-land #64)

### DIFF
--- a/bq-reverse-proxy/README.md
+++ b/bq-reverse-proxy/README.md
@@ -207,15 +207,12 @@ Optimization behavior (pricing mode, reservations, statement-level routing) is n
 
 ```hcl
 optimizer_configs = {
-  default = { default_pricing_mode_override = "on_demand" }
-  dbt     = {
-    reservation_ids          = ["my-project:EU.my-reservation"]
-    statement_level_override = true
-  }
+  default = { statementLevelOverride = true }
+  dbt     = { reservationIds = ["my-project:EU.my-reservation"] }
 }
 ```
 
-Fields (all optional — absent means "derived by the optimizer"): `reservation_ids` (list of `project:location.name` or full reservation resource names), `default_pricing_mode_override` (`on_demand` | `slot_based`), `statement_level_override` (bool).
+Each config object is passed to the optimizer as JSON **verbatim** (camelCase field names, the optimizer's contract), so new optimizer capabilities work without a module update. Currently accepted fields, all optional — absent means "derived by the optimizer": `reservationIds` (list of `project:location.name` or full reservation resource names) and `statementLevelOverride` (bool). The pricing mode is always derived per job project by the optimizer; `defaultPricingModeOverride` is rejected at plan time (and by the optimizer) from this path. Other field-level validation happens per request in the optimizer: an invalid config is logged on both sides and the query fails open (runs unoptimized, never blocked).
 
 How it works: the proxy forwards the matching alias's config with each job submission (the `x-rabbit-optimizer-config` header), where it takes precedence over the API key's server-side configuration. The config is not secret and is deliberately visible: it appears as a plain env var on the service, in the proxy's startup log, and on every optimizer request log line (`configSource: header`) — so "why did this query route on-demand?" is always answerable from the logs. Requires proxy image **v0.2.0 or newer**; against older Rabbit optimizer deployments the header is ignored and the server-side config applies.
 

--- a/bq-reverse-proxy/README.md
+++ b/bq-reverse-proxy/README.md
@@ -201,6 +201,24 @@ gcloud secrets add-iam-policy-binding my-rabbit-api-keys \
 
 `api_keys`, `create_api_keys_secret`, `api_keys_secret`, and the deprecated `default_api_key`/`api_key_routes` pair are mutually exclusive ways to configure the keys — Terraform fails the plan if more than one is set.
 
+## Per-Workload Optimizer Configuration
+
+Optimization behavior (pricing mode, reservations, statement-level routing) is normally configured on the Rabbit side per API key. `optimizer_configs` overrides it from your own deployment — self-service, no Rabbit UI involvement — keyed by the same aliases as `api_keys`, with `default` covering root traffic and any alias without its own entry:
+
+```hcl
+optimizer_configs = {
+  default = { default_pricing_mode_override = "on_demand" }
+  dbt     = {
+    reservation_ids          = ["my-project:EU.my-reservation"]
+    statement_level_override = true
+  }
+}
+```
+
+Fields (all optional — absent means "derived by the optimizer"): `reservation_ids` (list of `project:location.name` or full reservation resource names), `default_pricing_mode_override` (`on_demand` | `slot_based`), `statement_level_override` (bool).
+
+How it works: the proxy forwards the matching alias's config with each job submission (the `x-rabbit-optimizer-config` header), where it takes precedence over the API key's server-side configuration. The config is not secret and is deliberately visible: it appears as a plain env var on the service, in the proxy's startup log, and on every optimizer request log line (`configSource: header`) — so "why did this query route on-demand?" is always answerable from the logs. Requires proxy image **v0.2.0 or newer**; against older Rabbit optimizer deployments the header is ignored and the server-side config applies.
+
 ## Choosing an Access Model
 
 The proxy forwards your clients' BigQuery OAuth tokens as-is, so a request without a valid BigQuery credential can never read your data. However, the standard BigQuery client SDKs send OAuth access tokens scoped to BigQuery — **not** ID tokens audience-bound to the proxy URL — so they **cannot pass a Cloud Run IAM invoker gate**. Setting `allow_unauthenticated = false` for SDK/tool traffic results in HTML `401` responses from Cloud Run before requests ever reach the proxy.
@@ -585,6 +603,7 @@ These tools offer no BigQuery API endpoint override, so they cannot use the prox
 | `create_api_keys_secret` | No | `false` | Create a Secret Manager secret for the whole key map; you add the keys (`default=key0,alias1=key1`) as a secret version out-of-band. Needs image ≥ v0.2.0 |
 | `api_keys_secret` | No | `null` | Existing Secret Manager secret holding the key map (short id, or `projects/*/secrets/*` for cross-project). Needs image ≥ v0.2.0 |
 | `api_keys_secret_version` | No | `latest` | Secret version to pin when the keys come from Secret Manager |
+| `optimizer_configs` | No | `{}` | Per-workload optimizer config keyed by `api_keys` alias (see [Per-Workload Optimizer Configuration](#per-workload-optimizer-configuration)) |
 | `default_api_key` | No | `null` | **Deprecated** — use `api_keys = { default = "..." }`. Still works |
 | `api_key_routes` | No | `{}` | **Deprecated** — use `api_keys` with non-`default` aliases. Still works |
 | `image_registry` | No | `europe-docker.pkg.dev/.../bq-reverse-proxy` | Registry path without tag (see [Container Images](#container-images)) |

--- a/bq-reverse-proxy/terraform/main.tf
+++ b/bq-reverse-proxy/terraform/main.tf
@@ -36,6 +36,16 @@ locals {
   # secret's id, a caller-supplied secret reference, or null (plain env).
   api_keys_secret = var.create_api_keys_secret ? google_secret_manager_secret.api_keys[0].secret_id : var.api_keys_secret
 
+  # Per-alias optimizer configs rendered to the camelCase JSON the proxy
+  # forwards verbatim (null fields dropped so absent means "derive").
+  optimizer_configs_env = length(var.optimizer_configs) == 0 ? null : jsonencode({
+    for alias, c in var.optimizer_configs : alias => merge(
+      c.reservation_ids == null ? {} : { reservationIds = c.reservation_ids },
+      c.default_pricing_mode_override == null ? {} : { defaultPricingModeOverride = c.default_pricing_mode_override },
+      c.statement_level_override == null ? {} : { statementLevelOverride = c.statement_level_override },
+    )
+  })
+
   base_env = {
     # PORT is reserved by Cloud Run v2 — it is automatically set to match
     # the container port and cannot be overridden here.
@@ -187,6 +197,16 @@ resource "google_cloud_run_v2_service" "proxy" {
         content {
           name  = "API_KEY_ROUTES"
           value = join(",", [for alias, key in local.plain_routes : "${alias}=${key}"])
+        }
+      }
+
+      # Optional: per-workload optimizer configs. Plain env — the config is
+      # not sensitive and both proxy and optimizer log it for attribution.
+      dynamic "env" {
+        for_each = local.optimizer_configs_env == null ? [] : [1]
+        content {
+          name  = "OPTIMIZER_CONFIGS"
+          value = local.optimizer_configs_env
         }
       }
 

--- a/bq-reverse-proxy/terraform/main.tf
+++ b/bq-reverse-proxy/terraform/main.tf
@@ -36,15 +36,9 @@ locals {
   # secret's id, a caller-supplied secret reference, or null (plain env).
   api_keys_secret = var.create_api_keys_secret ? google_secret_manager_secret.api_keys[0].secret_id : var.api_keys_secret
 
-  # Per-alias optimizer configs rendered to the camelCase JSON the proxy
-  # forwards verbatim (null fields dropped so absent means "derive").
-  optimizer_configs_env = length(var.optimizer_configs) == 0 ? null : jsonencode({
-    for alias, c in var.optimizer_configs : alias => merge(
-      c.reservation_ids == null ? {} : { reservationIds = c.reservation_ids },
-      c.default_pricing_mode_override == null ? {} : { defaultPricingModeOverride = c.default_pricing_mode_override },
-      c.statement_level_override == null ? {} : { statementLevelOverride = c.statement_level_override },
-    )
-  })
+  # Per-alias optimizer configs, passed through verbatim — the map values
+  # already use the optimizer's camelCase field names.
+  optimizer_configs_env = length(var.optimizer_configs) == 0 ? null : jsonencode(var.optimizer_configs)
 
   base_env = {
     # PORT is reserved by Cloud Run v2 — it is automatically set to match

--- a/bq-reverse-proxy/terraform/terraform.tfvars.example
+++ b/bq-reverse-proxy/terraform/terraform.tfvars.example
@@ -38,9 +38,11 @@ api_keys = {
 # Optional: per-workload optimizer config, keyed by api_keys alias
 # ("default" = root traffic). Overrides the server-side per-key settings —
 # see "Per-Workload Optimizer Configuration" in the README.
+# Values are verbatim optimizer JSON (camelCase). Pricing mode is always
+# derived per job project and cannot be set here.
 # optimizer_configs = {
-#   default = { default_pricing_mode_override = "on_demand" }
-#   dbt     = { reservation_ids = ["my-project:EU.my-reservation"] }
+#   default = { statementLevelOverride = true }
+#   dbt     = { reservationIds = ["my-project:EU.my-reservation"] }
 # }
 
 # -----------------------------------------------------------------------

--- a/bq-reverse-proxy/terraform/terraform.tfvars.example
+++ b/bq-reverse-proxy/terraform/terraform.tfvars.example
@@ -35,6 +35,14 @@ api_keys = {
 # api_keys_secret         = "projects/other-proj/secrets/my-rabbit-keys"
 # api_keys_secret_version = "latest"
 
+# Optional: per-workload optimizer config, keyed by api_keys alias
+# ("default" = root traffic). Overrides the server-side per-key settings —
+# see "Per-Workload Optimizer Configuration" in the README.
+# optimizer_configs = {
+#   default = { default_pricing_mode_override = "on_demand" }
+#   dbt     = { reservation_ids = ["my-project:EU.my-reservation"] }
+# }
+
 # -----------------------------------------------------------------------
 # Access model — pick one
 # -----------------------------------------------------------------------

--- a/bq-reverse-proxy/terraform/variables.tf
+++ b/bq-reverse-proxy/terraform/variables.tf
@@ -141,6 +141,47 @@ variable "api_keys_secret_version" {
   default     = "latest"
 }
 
+variable "optimizer_configs" {
+  type = map(object({
+    reservation_ids               = optional(list(string))
+    default_pricing_mode_override = optional(string)
+    statement_level_override      = optional(bool)
+  }))
+  description = <<EOT
+Per-workload BQ Job Optimizer config, keyed by the same aliases as
+`api_keys` (the reserved alias "default" covers root traffic and any alias
+without its own entry). Overrides the server-side per-key configuration for
+requests going through this deployment — fully self-service, no Rabbit UI
+involvement. Example:
+
+  optimizer_configs = {
+    default = { default_pricing_mode_override = "on_demand" }
+    dbt     = { reservation_ids = ["my-project:EU.my-reservation"] }
+  }
+
+The config is not secret (reservation names + mode flags); it is rendered
+as a plain env var and logged by both the proxy and the optimizer for
+per-request attribution. Requires proxy image >= v0.2.0.
+EOT
+  default     = {}
+
+  validation {
+    condition = alltrue([
+      for alias, _ in var.optimizer_configs :
+      can(regex("^[^/]+$", alias)) && !contains(["bigquery", "upload", "batch", "discovery", "healthz", "readyz", "metrics"], alias)
+    ])
+    error_message = "Aliases must be single path segments and must not be a reserved segment (bigquery, upload, batch, discovery, healthz, readyz, metrics)."
+  }
+
+  validation {
+    condition = alltrue([
+      for _, c in var.optimizer_configs :
+      c.default_pricing_mode_override == null || contains(["on_demand", "slot_based"], coalesce(c.default_pricing_mode_override, "on_demand"))
+    ])
+    error_message = "default_pricing_mode_override must be \"on_demand\" or \"slot_based\"."
+  }
+}
+
 variable "default_api_key" {
   type        = string
   sensitive   = true

--- a/bq-reverse-proxy/terraform/variables.tf
+++ b/bq-reverse-proxy/terraform/variables.tf
@@ -142,43 +142,55 @@ variable "api_keys_secret_version" {
 }
 
 variable "optimizer_configs" {
-  type = map(object({
-    reservation_ids               = optional(list(string))
-    default_pricing_mode_override = optional(string)
-    statement_level_override      = optional(bool)
-  }))
+  # `any` rather than map(object): values are passed through as JSON
+  # verbatim, and map(any) would force every alias's config to have the
+  # same shape.
+  type        = any
   description = <<EOT
 Per-workload BQ Job Optimizer config, keyed by the same aliases as
 `api_keys` (the reserved alias "default" covers root traffic and any alias
 without its own entry). Overrides the server-side per-key configuration for
 requests going through this deployment — fully self-service, no Rabbit UI
-involvement. Example:
+involvement.
+
+Each value is passed to the optimizer as JSON verbatim, so field names use
+the optimizer's camelCase contract and new optimizer capabilities need no
+module update. Currently accepted fields: `reservationIds` (list),
+`statementLevelOverride` (bool). The pricing mode is derived per job
+project by the optimizer and cannot be set from this direction. Example:
 
   optimizer_configs = {
-    default = { default_pricing_mode_override = "on_demand" }
-    dbt     = { reservation_ids = ["my-project:EU.my-reservation"] }
+    default = { statementLevelOverride = true }
+    dbt     = { reservationIds = ["my-project:EU.my-reservation"] }
   }
 
-The config is not secret (reservation names + mode flags); it is rendered
-as a plain env var and logged by both the proxy and the optimizer for
-per-request attribution. Requires proxy image >= v0.2.0.
+Field-level validation happens in the optimizer: an invalid config is
+rejected per request (logged on both sides, queries fail open — never
+blocked). The config is not secret; it is rendered as a plain env var and
+logged by both the proxy and the optimizer for per-request attribution.
+Requires proxy image >= v0.2.0.
 EOT
   default     = {}
 
   validation {
-    condition = alltrue([
+    condition     = can(keys(var.optimizer_configs)) && try(alltrue([for _, c in var.optimizer_configs : can(keys(c))]), false) || try(length(var.optimizer_configs) == 0, false)
+    error_message = "optimizer_configs must be a map of alias => config object."
+  }
+
+  validation {
+    condition = try(alltrue([
       for alias, _ in var.optimizer_configs :
       can(regex("^[^/]+$", alias)) && !contains(["bigquery", "upload", "batch", "discovery", "healthz", "readyz", "metrics"], alias)
-    ])
+    ]), true)
     error_message = "Aliases must be single path segments and must not be a reserved segment (bigquery, upload, batch, discovery, healthz, readyz, metrics)."
   }
 
   validation {
-    condition = alltrue([
+    condition = try(alltrue([
       for _, c in var.optimizer_configs :
-      c.default_pricing_mode_override == null || contains(["on_demand", "slot_based"], coalesce(c.default_pricing_mode_override, "on_demand"))
-    ])
-    error_message = "default_pricing_mode_override must be \"on_demand\" or \"slot_based\"."
+      !contains(keys(c), "defaultPricingModeOverride")
+    ]), true)
+    error_message = "defaultPricingModeOverride cannot be set per proxy route — the optimizer derives the pricing mode per job project."
   }
 }
 


### PR DESCRIPTION
Re-lands #64, which was merged into its stacked base branch (`feat/bq-proxy-secret-api-key`) instead of being retargeted to master after #63 merged — its changes never reached master.

Content is identical to reviewed #64: `optimizer_configs` map keyed by `api_keys` alias, verbatim camelCase JSON rendered to the proxy's `OPTIMIZER_CONFIGS` env var, `defaultPricingModeOverride` rejected at plan time. Already validated end-to-end (optimizer live in dev, proxy v0.2.1 released, sandbox deployment tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)