### PR TITLE
feat(bq-reverse-proxy): add secret_locations and default_uri_disabled

### DIFF
--- a/bq-reverse-proxy/README.md
+++ b/bq-reverse-proxy/README.md
@@ -58,7 +58,7 @@ Before deploying, ensure you have:
   ```
 
   If you store the Rabbit API key in Secret Manager (recommended — see [Storing the API Keys in Secret Manager](#storing-the-api-keys-in-secret-manager)), also enable `secretmanager.googleapis.com`.
-2. **Terraform** >= 1.6 installed locally ([install guide](https://developer.hashicorp.com/terraform/install))
+2. **Terraform** >= 1.6 installed locally ([install guide](https://developer.hashicorp.com/terraform/install)), with the **Google provider >= 7.7.0** (the release that promoted `default_uri_disabled` to GA — the module pins `>= 7.7.0, < 8.0`). If you are upgrading from an older pin, run `terraform init -upgrade`.
 3. **gcloud CLI** authenticated with a principal that has permissions to create Cloud Run services, service accounts, and IAM bindings. You need **two** logins:
   - `gcloud auth login` — for gcloud CLI commands
   - `gcloud auth application-default login` — Terraform's Google provider authenticates via [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) (ADC), which is separate from your gcloud CLI login. Without ADC, `terraform plan`/`apply` fails with a credentials error.
@@ -201,6 +201,19 @@ gcloud secrets add-iam-policy-binding my-rabbit-api-keys \
 
 `api_keys`, `create_api_keys_secret`, `api_keys_secret`, and the deprecated `default_api_key`/`api_key_routes` pair are mutually exclusive ways to configure the keys — Terraform fails the plan if more than one is set.
 
+### Pinning secrets to a region
+
+By default Secret Manager replicates a secret automatically across regions (Google-managed, global). If your organization requires secrets to stay in named locations, set `secret_locations`:
+
+```hcl
+create_api_keys_secret = true
+secret_locations       = ["europe-west3"]   # or [var.region], or several regions
+```
+
+This is module-wide rather than per-secret: it applies to every secret the module creates, so residency is configured once. It does **not** apply to a secret you bring yourself via `api_keys_secret` — that one is replicated however you created it.
+
+> **Replication is immutable.** Adding, changing, or removing `secret_locations` on an existing module-managed secret makes Terraform **destroy and recreate** it, which deletes all of its versions. Check the plan, and re-add the keys (`gcloud secrets versions add …`) after the apply.
+
 ## Per-Workload Optimizer Configuration
 
 Optimization behavior (pricing mode, reservations, statement-level routing) is normally configured on the Rabbit side per API key. `optimizer_configs` overrides it from your own deployment — self-service, no Rabbit UI involvement — keyed by the same aliases as `api_keys`, with `default` covering root traffic and any alias without its own entry:
@@ -228,6 +241,8 @@ Protect the endpoint at the network layer instead:
 | **Internal (recommended)** | `allow_unauthenticated = true`, `ingress = "INGRESS_TRAFFIC_INTERNAL_ONLY"` | All clients run inside your GCP project / VPC / VPC-SC perimeter (Composer, in-VPC Airflow, dbt on GCE). The URL is unreachable from the internet. |
 | **Internal + Load Balancer** | `allow_unauthenticated = true`, `ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"` | You want to front the proxy with your own Google Cloud Load Balancer (custom domain, Cloud Armor allowlists). |
 | **Public** | `allow_unauthenticated = true`, `ingress = "INGRESS_TRAFFIC_ALL"` | You use SaaS clients that connect from outside your network (Looker, dbt Cloud). |
+
+Orthogonal to all three: `default_uri_disabled = true` turns off public resolution of the built-in `*.run.app` hostname, so the service is only reachable through an entry point you control. `ingress` decides *where traffic may come from*; this decides *whether the default hostname exists at all*. Pair it with the load-balancer model when policy forbids a Google-assigned public hostname. The `service_url` output still reports that URI, but it will no longer resolve — point clients at your own endpoint.
 
 For the **public** model, note what exposure actually means: the proxy is stateless and holds no data — an anonymous caller without a valid BigQuery OAuth token gets errors from BigQuery, exactly as if they hit `bigquery.googleapis.com` directly. If you want to additionally restrict which networks can reach a public endpoint, put it behind a load balancer with [Cloud Armor](https://cloud.google.com/armor) IP allowlists.
 
@@ -600,6 +615,7 @@ These tools offer no BigQuery API endpoint override, so they cannot use the prox
 | `create_api_keys_secret` | No | `false` | Create a Secret Manager secret for the whole key map; you add the keys (`default=key0,alias1=key1`) as a secret version out-of-band. Needs image ≥ v0.2.0 |
 | `api_keys_secret` | No | `null` | Existing Secret Manager secret holding the key map (short id, or `projects/*/secrets/*` for cross-project). Needs image ≥ v0.2.0 |
 | `api_keys_secret_version` | No | `latest` | Secret version to pin when the keys come from Secret Manager |
+| `secret_locations` | No | `[]` (automatic/global) | Regions every module-created secret is replicated to (see [Pinning secrets to a region](#pinning-secrets-to-a-region)). Changing it recreates the secret |
 | `optimizer_configs` | No | `{}` | Per-workload optimizer config keyed by `api_keys` alias (see [Per-Workload Optimizer Configuration](#per-workload-optimizer-configuration)) |
 | `default_api_key` | No | `null` | **Deprecated** — use `api_keys = { default = "..." }`. Still works |
 | `api_key_routes` | No | `{}` | **Deprecated** — use `api_keys` with non-`default` aliases. Still works |
@@ -607,6 +623,7 @@ These tools offer no BigQuery API endpoint override, so they cannot use the prox
 | `image_tag` | No | `latest` | Image version to deploy. Set a release tag (e.g. `v0.1.0`) to pin |
 | `allow_unauthenticated` | No | `false` | Grant `run.invoker` to `allUsers` (see [Choosing an Access Model](#choosing-an-access-model)) |
 | `ingress` | No | `INGRESS_TRAFFIC_ALL` | `..._ALL`, `..._INTERNAL_ONLY`, or `..._INTERNAL_LOAD_BALANCER` |
+| `default_uri_disabled` | No | `false` | Disable public resolution of the default `*.run.app` URI (see [Choosing an Access Model](#choosing-an-access-model)). Needs google provider ≥ 7.7.0 |
 | `invoker_members` | No | `[]` | IAM principals granted `run.invoker` (only when `allow_unauthenticated = false`) |
 | `service_name` | No | `bq-reverse-proxy` | Cloud Run service name |
 | `service_account_email` | No | `null` (created) | Bring your own runtime service account |

--- a/bq-reverse-proxy/terraform/main.tf
+++ b/bq-reverse-proxy/terraform/main.tf
@@ -3,8 +3,10 @@ terraform {
 
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 5.0, < 8.0"
+      source = "hashicorp/google"
+      # >= 7.7.0: first GA release with default_uri_disabled on
+      # google_cloud_run_v2_service (beta-only before that).
+      version = ">= 7.7.0, < 8.0"
     }
   }
 }
@@ -35,6 +37,11 @@ locals {
   # Secret Manager source for the whole key map: the module-created
   # secret's id, a caller-supplied secret reference, or null (plain env).
   api_keys_secret = var.create_api_keys_secret ? google_secret_manager_secret.api_keys[0].secret_id : var.api_keys_secret
+
+  # Replication mode for every secret the module creates: user-managed (one
+  # replica per var.secret_locations entry) when locations are pinned,
+  # Google-managed automatic/global otherwise.
+  secret_user_managed = length(var.secret_locations) > 0
 
   # Per-alias optimizer configs, passed through verbatim — the map values
   # already use the optimizer's camelCase field names.
@@ -74,8 +81,26 @@ resource "google_secret_manager_secret" "api_keys" {
   secret_id = "${var.service_name}-api-keys"
   labels    = local.base_labels
 
+  # Automatic (global) replication unless var.secret_locations pins regions —
+  # some organizations require secrets to be region-bound for data residency.
+  # Every secret this module creates uses this same block.
   replication {
-    auto {}
+    dynamic "auto" {
+      for_each = local.secret_user_managed ? [] : [1]
+      content {}
+    }
+
+    dynamic "user_managed" {
+      for_each = local.secret_user_managed ? [1] : []
+      content {
+        dynamic "replicas" {
+          for_each = var.secret_locations
+          content {
+            location = replicas.value
+          }
+        }
+      }
+    }
   }
 }
 
@@ -97,8 +122,9 @@ resource "google_cloud_run_v2_service" "proxy" {
   name     = var.service_name
   labels   = local.base_labels
 
-  ingress             = var.ingress
-  deletion_protection = false
+  ingress              = var.ingress
+  default_uri_disabled = var.default_uri_disabled
+  deletion_protection  = false
 
   template {
     service_account = local.effective_sa_email

--- a/bq-reverse-proxy/terraform/outputs.tf
+++ b/bq-reverse-proxy/terraform/outputs.tf
@@ -4,7 +4,7 @@ output "service_name" {
 }
 
 output "service_url" {
-  description = "HTTPS URL of the proxy. Point BigQuery clients' root URL at this (replacing https://bigquery.googleapis.com)."
+  description = "HTTPS URL of the proxy. Point BigQuery clients' root URL at this (replacing https://bigquery.googleapis.com). With default_uri_disabled = true this default URI no longer resolves — use your own endpoint instead."
   value       = google_cloud_run_v2_service.proxy.uri
 }
 

--- a/bq-reverse-proxy/terraform/terraform.tfvars.example
+++ b/bq-reverse-proxy/terraform/terraform.tfvars.example
@@ -35,6 +35,12 @@ api_keys = {
 # api_keys_secret         = "projects/other-proj/secrets/my-rabbit-keys"
 # api_keys_secret_version = "latest"
 
+# Optional: pin every secret this module creates to specific regions instead
+# of Google-managed global replication (data residency policies). Empty =
+# automatic/global. Replication is immutable — changing this recreates the
+# secret and drops its versions.
+# secret_locations = ["europe-west3"]
+
 # Optional: per-workload optimizer config, keyed by api_keys alias
 # ("default" = root traffic). Overrides the server-side per-key settings —
 # see "Per-Workload Optimizer Configuration" in the README.
@@ -65,6 +71,12 @@ api_keys = {
 
 allow_unauthenticated = true
 ingress               = "INGRESS_TRAFFIC_ALL"
+
+# Orthogonal to ingress: turn off public resolution of the built-in
+# *.run.app hostname, so the service is only reachable through an entry
+# point you control (e.g. your own load balancer). Needs google provider
+# >= 7.7.0.
+# default_uri_disabled = true
 
 # -----------------------------------------------------------------------
 # Image — pick the regional mirror closest to your Cloud Run region

--- a/bq-reverse-proxy/terraform/variables.tf
+++ b/bq-reverse-proxy/terraform/variables.tf
@@ -227,6 +227,32 @@ EOT
 }
 
 # -----------------------------------------------------------------------
+# Secret Manager
+# -----------------------------------------------------------------------
+
+variable "secret_locations" {
+  type        = list(string)
+  description = <<EOT
+Regions every Secret Manager secret this module creates is replicated to
+(user-managed replication), e.g. ["europe-west3"] or [var.region]. Set this
+when your organization requires secrets to be region-bound rather than
+globally replicated. The empty default keeps Google-managed automatic
+(global) replication.
+
+Module-wide on purpose: it covers the API keys secret
+(`create_api_keys_secret = true`) and any further secret the module grows
+later, so residency is configured once rather than per secret. It does NOT
+touch secrets you bring yourself via `api_keys_secret` — those are
+replicated however you created them.
+
+Replication is immutable in Secret Manager: changing this on an existing
+secret makes Terraform destroy and recreate it, which deletes every secret
+version with it. Re-add the keys afterwards (see the README).
+EOT
+  default     = []
+}
+
+# -----------------------------------------------------------------------
 # Runtime knobs
 # -----------------------------------------------------------------------
 
@@ -309,6 +335,23 @@ EOT
     ], var.ingress)
     error_message = "ingress must be one of INGRESS_TRAFFIC_ALL | INGRESS_TRAFFIC_INTERNAL_ONLY | INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
   }
+}
+
+variable "default_uri_disabled" {
+  type        = bool
+  description = <<EOT
+Disable public resolution of the Cloud Run default `*.run.app` URI, so the
+service can only be reached through an entry point you control (a load
+balancer, or another internal address). Independent of `ingress`: ingress
+controls where traffic may come from, this removes the built-in hostname.
+
+The `service_url` output stays populated with the (now unresolvable) default
+URI — point clients at your own endpoint instead.
+
+Requires google provider >= 7.7.0 (the release that promoted this field out
+of beta), which is this module's minimum anyway.
+EOT
+  default     = false
 }
 
 variable "invoker_members" {


### PR DESCRIPTION
Requested by the **GFS** customer (corporate security policy). Closes #70.

## What

**1. `secret_locations`** (list of regions, default `[]`)

`google_secret_manager_secret.api_keys` was hardcoded to `replication { auto {} }` — Google-managed global replication, which GFS's policy forbids. The variable drives user-managed replication instead:

```hcl
create_api_keys_secret = true
secret_locations       = ["europe-west3"]   # or [var.region], or several
```

Module-wide rather than scoped to the API keys secret, so residency is configured once and any secret the module grows later inherits it via the same `replication` block. Bring-your-own secrets (`api_keys_secret`) are untouched — the module doesn't own them. Empty (default) keeps today's `auto {}`.

**2. `default_uri_disabled`** (bool, default `false`)

Disables public resolution of the built-in `*.run.app` hostname, so the service is reachable only through an entry point the customer controls. Orthogonal to `ingress`: ingress controls *where traffic may come from*, this controls *whether the default hostname exists at all*.

Both default to current behavior, so existing deployments plan clean.

## ⚠️ Breaking: provider floor bumped to 7.7.0

`required_providers` moves from `>= 5.0, < 8.0` to `>= 7.7.0, < 8.0`. `default_uri_disabled` was beta-only in the `google` provider until it was promoted to GA in [7.7.0](https://github.com/hashicorp/terraform-provider-google/blob/main/CHANGELOG.md), and Terraform rejects an attribute that isn't in the provider schema even when set to `null` — so it can't be made conditional on the variable. Consumers pinned to provider 5.x/6.x need `terraform init -upgrade`. Called out in the README prerequisites.

Also worth flagging for anyone adopting `secret_locations` later: **Secret Manager replication is immutable**, so changing it on an existing secret destroys and recreates it, dropping every version. Warned about in the README and the tfvars example.

## Verification

`terraform fmt -check`, `terraform validate`, and `terraform plan` against both branches:

```
# secret_locations = ["europe-west3"], default_uri_disabled = true
+ default_uri_disabled    = true
+ replication {
    + user_managed {
        + replicas {
            + location = "europe-west3"

# defaults
+ replication {
    + auto {
      }
```

## Out of scope

`optimizer_configs` stays a plain env var (documented as non-secret, logged by both proxy and optimizer for per-request attribution). If it ever moves into Secret Manager, `secret_locations` covers it with no further change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
