### PR TITLE
feat(bq-reverse-proxy): support Direct VPC egress for a fixed egress IP

### DIFF
--- a/bq-reverse-proxy/README.md
+++ b/bq-reverse-proxy/README.md
@@ -636,8 +636,10 @@ These tools offer no BigQuery API endpoint override, so they cannot use the prox
 | `request_timeout` | No | `10m` | Upstream request timeout (Go duration) |
 | `bq_job_optimizer_timeout` | No | `2s` | Optimizer call timeout (Go duration); fail-open on expiry |
 | `max_body_bytes` | No | `1048576` | Max body size buffered for optimization; larger bodies pass through untouched |
-| `vpc_connector` | No | `null` | VPC access connector ID |
-| `vpc_egress` | No | `PRIVATE_RANGES_ONLY` | VPC egress mode (only with `vpc_connector`) |
+| `vpc_connector` | No | `null` | VPC access connector ID. Mutually exclusive with `vpc_network` |
+| `vpc_network` | No | `null` | Direct VPC egress network, `projects/<host>/global/networks/<name>`. No connector instances needed |
+| `vpc_subnetwork` | No | `null` | Direct VPC egress subnetwork, `projects/<host>/regions/<region>/subnetworks/<name>`. Region must match the service. Required with `vpc_network` |
+| `vpc_egress` | No | `PRIVATE_RANGES_ONLY` | VPC egress mode. Use `ALL_TRAFFIC` to route googleapis calls through the VPC |
 | `labels` | No | `{}` | Labels for created resources |
 | `extra_env` | No | `{}` | Extra container environment variables |
 

--- a/bq-reverse-proxy/terraform/main.tf
+++ b/bq-reverse-proxy/terraform/main.tf
@@ -135,12 +135,24 @@ resource "google_cloud_run_v2_service" "proxy" {
       max_instance_count = var.max_instances
     }
 
-    # VPC connector (optional).
+    # VPC egress (optional) — either a connector (var.vpc_connector) or
+    # Direct VPC egress (var.vpc_network + var.vpc_subnetwork). Direct is
+    # preferred: no connector VMs to size or pay for, and it is what gives
+    # the service a fixed NAT egress IP when the subnet's Private Google
+    # Access is off.
     dynamic "vpc_access" {
-      for_each = var.vpc_connector == null ? [] : [1]
+      for_each = var.vpc_connector == null && var.vpc_network == null ? [] : [1]
       content {
         connector = var.vpc_connector
         egress    = var.vpc_egress
+
+        dynamic "network_interfaces" {
+          for_each = var.vpc_network == null ? [] : [1]
+          content {
+            network    = var.vpc_network
+            subnetwork = var.vpc_subnetwork
+          }
+        }
       }
     }
 
@@ -270,6 +282,18 @@ resource "google_cloud_run_v2_service" "proxy" {
         nonsensitive(var.default_api_key != null || length(var.api_key_routes) > 0),
       ] : set if set]) <= 1
       error_message = "Configure the API keys through exactly one mechanism: api_keys, create_api_keys_secret, api_keys_secret, or the deprecated default_api_key/api_key_routes pair."
+    }
+
+    # Cloud Run rejects these combinations with an opaque API error; catch
+    # them at plan time instead.
+    precondition {
+      condition     = var.vpc_network == null || var.vpc_subnetwork != null
+      error_message = "vpc_subnetwork is required when vpc_network is set — Direct VPC egress needs both."
+    }
+
+    precondition {
+      condition     = var.vpc_connector == null || var.vpc_network == null
+      error_message = "Set either vpc_connector or vpc_network, not both — a service uses one egress mechanism."
     }
   }
 }

--- a/bq-reverse-proxy/terraform/variables.tf
+++ b/bq-reverse-proxy/terraform/variables.tf
@@ -410,6 +410,32 @@ variable "vpc_egress" {
   default     = "PRIVATE_RANGES_ONLY"
 }
 
+variable "vpc_network" {
+  type        = string
+  description = <<EOT
+Fully-qualified network for Direct VPC egress
+(`projects/<host>/global/networks/<name>`). Set together with
+`vpc_subnetwork` as an alternative to `vpc_connector` — Direct VPC egress
+needs no connector instances. Leave null for public (serverless) egress.
+
+Point this at a subnet whose Private Google Access is OFF and whose region
+has a Cloud NAT with reserved static IPs to give the proxy a fixed,
+allowlistable egress IP — required when the BigQuery it fronts sits behind
+VPC Service Controls.
+EOT
+  default     = null
+}
+
+variable "vpc_subnetwork" {
+  type        = string
+  description = <<EOT
+Fully-qualified subnetwork for Direct VPC egress
+(`projects/<host>/regions/<region>/subnetworks/<name>`). Must be in the
+same region as the service. Required when `vpc_network` is set.
+EOT
+  default     = null
+}
+
 variable "labels" {
   type        = map(string)
   description = "Labels applied to every resource this module creates."


### PR DESCRIPTION
## Why

The proxy module could only route egress through a VPC access connector. Cloud Run's **Direct VPC egress** needs no connector instances and is what lets the service leave from a subnet whose region has a Cloud NAT with reserved static IPs — i.e. a fixed, allowlistable egress IP.

This matters when the BigQuery the proxy fronts sits behind **VPC Service Controls**. Today Rabbit's own `bq-reverse-proxy` deployment has no VPC egress configured at all, so its calls to `bigquery.googleapis.com` leave as bare serverless traffic with **no source attribution**: no ingress rule scoped by IP or by `resource:` can match it, leaving `accessLevel: "*"` (Any source) as the only thing that works. Customers who refuse Any-source have no option today.

## What

- `vpc_network` + `vpc_subnetwork` variables (both default `null`, so this is a no-op for every existing consumer).
- The existing `dynamic "vpc_access"` block now also fires when `vpc_network` is set, and emits a `network_interfaces` sub-block.
- Two plan-time preconditions for the misconfigurations Cloud Run only surfaces as an opaque API error:
  - `vpc_network` set without `vpc_subnetwork`
  - `vpc_connector` and `vpc_network` set together
- README variable table updated.

## Notes

- Pair with `vpc_egress = "ALL_TRAFFIC"`; `PRIVATE_RANGES_ONLY` leaves googleapis calls on the public path and defeats the purpose.
- The subnetwork must be region-local to the service, and its Private Google Access must be **off** for googleapis traffic to take the NAT path.
- On a shared VPC the Cloud Run service agent of the service project needs `roles/compute.networkUser` on the host project or subnet.

## Verification

`terraform validate` passes; `terraform fmt` clean. Defaults unchanged, so a consumer that sets neither new variable produces an identical plan.

Part of a four-repo change giving Rabbit's `bq-reverse-proxy` a fixed egress IP — see the linked PRs in `bq-reverse-proxy`, `gcp-foundation` and `rabbit-app`. This one merges first (the others reference the module on `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)